### PR TITLE
Update client to the latest, add circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.10.3
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/killbill/kbcli
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -18,7 +18,20 @@ go get -u github.com/killbill/kbcli
     trp.Producers["text/xml"] = runtime.TextProducer()
     // Set this to true to dump http messages
     trp.Debug = false
-    authWriter := httptransport.BasicAuth("admin"/*username*/, "password" /**password*/)
+    // Authentication
+    authWriter := runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {
+        encoded := base64.StdEncoding.EncodeToString([]byte("admin"/*username*/ + ":" + "password" /**password*/))
+        if err := r.SetHeaderParam("Authorization", "Basic "+encoded); err != nil {
+            return err
+        }
+        if err := r.SetHeaderParam("X-KillBill-ApiKey", apiKey); err != nil {
+            return err
+        }
+        if err := r.SetHeaderParam("X-KillBill-ApiSecret", apiSecret); err != nil {
+            return err
+        }
+        return nil
+    })
     client := kbclient.New(trp, strfmt.Default, authWriter, kbclient.KillbillDefaults{})
 ```
 

--- a/examples/listaccounts/main.go
+++ b/examples/listaccounts/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/go-openapi/runtime"
@@ -18,19 +19,29 @@ func NewClient() *kbclient.KillBill {
 	trp.Producers["text/xml"] = runtime.TextProducer()
 	// Set this to true to dump http messages
 	trp.Debug = false
-	authWriter := httptransport.BasicAuth("admin" /*username*/, "password" /**password*/)
+	apiKey := "bob"
+	apiSecret := "lazar"
+	authWriter := runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {
+		encoded := base64.StdEncoding.EncodeToString([]byte("admin" /*username*/ + ":" + "password" /**password*/))
+		if err := r.SetHeaderParam("Authorization", "Basic "+encoded); err != nil {
+			return err
+		}
+		if err := r.SetHeaderParam("X-KillBill-ApiKey", apiKey); err != nil {
+			return err
+		}
+		if err := r.SetHeaderParam("X-KillBill-ApiSecret", apiSecret); err != nil {
+			return err
+		}
+		return nil
+	})
 	client := kbclient.New(trp, strfmt.Default, authWriter, kbclient.KillbillDefaults{})
 
 	// Set defaults. You can override them in each API call.
-	apiKey := "bob"
-	apiSecret := "lazar"
 	createdBy := "John Doe"
 	comment := "Created by John Doe"
 	reason := ""
 
 	client.SetDefaults(kbclient.KillbillDefaults{
-		APIKey:    &apiKey,
-		APISecret: &apiSecret,
 		CreatedBy: &createdBy,
 		Comment:   &comment,
 		Reason:    &reason,

--- a/kbclient/account/account_client.go
+++ b/kbclient/account/account_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -168,11 +164,6 @@ type IAccount interface {
 	GetChildrenAccounts(ctx context.Context, params *GetChildrenAccountsParams) (*GetChildrenAccountsOK, error)
 
 	/*
-		GetEmailNotificationsForAccount retrieves account email notification
-	*/
-	GetEmailNotificationsForAccount(ctx context.Context, params *GetEmailNotificationsForAccountParams) (*GetEmailNotificationsForAccountOK, *GetEmailNotificationsForAccountNoContent, error)
-
-	/*
 		GetEmails retrieves an account emails
 	*/
 	GetEmails(ctx context.Context, params *GetEmailsParams) (*GetEmailsOK, error)
@@ -248,11 +239,6 @@ type IAccount interface {
 	SetDefaultPaymentMethod(ctx context.Context, params *SetDefaultPaymentMethodParams) (*SetDefaultPaymentMethodNoContent, error)
 
 	/*
-		SetEmailNotificationsForAccount sets account email notification
-	*/
-	SetEmailNotificationsForAccount(ctx context.Context, params *SetEmailNotificationsForAccountParams) (*SetEmailNotificationsForAccountNoContent, error)
-
-	/*
 		TransferChildCreditToParent moves a given child credit to the parent level
 	*/
 	TransferChildCreditToParent(ctx context.Context, params *TransferChildCreditToParentParams) (*TransferChildCreditToParentNoContent, error)
@@ -274,31 +260,18 @@ func (a *Client) AddAccountBlockingState(ctx context.Context, params *AddAccount
 	getParams := NewAddAccountBlockingStateParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -357,31 +330,18 @@ func (a *Client) AddEmail(ctx context.Context, params *AddEmailParams) (*AddEmai
 	getParams := NewAddEmailParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -438,14 +398,6 @@ func (a *Client) CloseAccount(ctx context.Context, params *CloseAccountParams) (
 		params = NewCloseAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -493,31 +445,18 @@ func (a *Client) CreateAccount(ctx context.Context, params *CreateAccountParams)
 	getParams := NewCreateAccountParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -576,31 +515,18 @@ func (a *Client) CreateAccountCustomFields(ctx context.Context, params *CreateAc
 	getParams := NewCreateAccountCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -659,31 +585,18 @@ func (a *Client) CreateAccountTags(ctx context.Context, params *CreateAccountTag
 	getParams := NewCreateAccountTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -742,31 +655,18 @@ func (a *Client) CreatePaymentMethod(ctx context.Context, params *CreatePaymentM
 	getParams := NewCreatePaymentMethodParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -823,14 +723,6 @@ func (a *Client) DeleteAccountCustomFields(ctx context.Context, params *DeleteAc
 		params = NewDeleteAccountCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -876,14 +768,6 @@ func (a *Client) DeleteAccountTags(ctx context.Context, params *DeleteAccountTag
 		params = NewDeleteAccountTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -929,14 +813,6 @@ func (a *Client) GetAccount(ctx context.Context, params *GetAccountParams) (*Get
 		params = NewGetAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -970,14 +846,6 @@ func (a *Client) GetAccountAuditLogs(ctx context.Context, params *GetAccountAudi
 		params = NewGetAccountAuditLogsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1011,14 +879,6 @@ func (a *Client) GetAccountAuditLogsWithHistory(ctx context.Context, params *Get
 		params = NewGetAccountAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1052,14 +912,6 @@ func (a *Client) GetAccountBundles(ctx context.Context, params *GetAccountBundle
 		params = NewGetAccountBundlesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1093,14 +945,6 @@ func (a *Client) GetAccountByKey(ctx context.Context, params *GetAccountByKeyPar
 		params = NewGetAccountByKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1134,14 +978,6 @@ func (a *Client) GetAccountCustomFields(ctx context.Context, params *GetAccountC
 		params = NewGetAccountCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1175,14 +1011,6 @@ func (a *Client) GetAccountEmailAuditLogsWithHistory(ctx context.Context, params
 		params = NewGetAccountEmailAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1216,14 +1044,6 @@ func (a *Client) GetAccountTags(ctx context.Context, params *GetAccountTagsParam
 		params = NewGetAccountTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1257,14 +1077,6 @@ func (a *Client) GetAccountTimeline(ctx context.Context, params *GetAccountTimel
 		params = NewGetAccountTimelineParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1298,14 +1110,6 @@ func (a *Client) GetAccounts(ctx context.Context, params *GetAccountsParams) (*G
 		params = NewGetAccountsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1339,14 +1143,6 @@ func (a *Client) GetAllCustomFields(ctx context.Context, params *GetAllCustomFie
 		params = NewGetAllCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1380,14 +1176,6 @@ func (a *Client) GetAllTags(ctx context.Context, params *GetAllTagsParams) (*Get
 		params = NewGetAllTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1421,14 +1209,6 @@ func (a *Client) GetBlockingStates(ctx context.Context, params *GetBlockingState
 		params = NewGetBlockingStatesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1462,14 +1242,6 @@ func (a *Client) GetChildrenAccounts(ctx context.Context, params *GetChildrenAcc
 		params = NewGetChildrenAccountsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1495,53 +1267,6 @@ func (a *Client) GetChildrenAccounts(ctx context.Context, params *GetChildrenAcc
 }
 
 /*
-GetEmailNotificationsForAccount retrieves account email notification
-*/
-func (a *Client) GetEmailNotificationsForAccount(ctx context.Context, params *GetEmailNotificationsForAccountParams) (*GetEmailNotificationsForAccountOK, *GetEmailNotificationsForAccountNoContent, error) {
-	// TODO: Validate the params before sending
-	if params == nil {
-		params = NewGetEmailNotificationsForAccountParams()
-	}
-	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
-	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
-		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
-	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
-		ID:                 "getEmailNotificationsForAccount",
-		Method:             "GET",
-		PathPattern:        "/1.0/kb/accounts/{accountId}/emailNotifications",
-		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{""},
-		Schemes:            []string{"http"},
-		Params:             params,
-		Reader:             &GetEmailNotificationsForAccountReader{formats: a.formats},
-		AuthInfo:           a.authInfo,
-		Context:            params.Context,
-		Client:             params.HTTPClient,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	switch value := result.(type) {
-	case *GetEmailNotificationsForAccountOK:
-		return value, nil, nil
-	case *GetEmailNotificationsForAccountNoContent:
-		return nil, value, nil
-	}
-	return nil, nil, nil
-
-}
-
-/*
 GetEmails retrieves an account emails
 */
 func (a *Client) GetEmails(ctx context.Context, params *GetEmailsParams) (*GetEmailsOK, error) {
@@ -1550,14 +1275,6 @@ func (a *Client) GetEmails(ctx context.Context, params *GetEmailsParams) (*GetEm
 		params = NewGetEmailsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1591,14 +1308,6 @@ func (a *Client) GetInvoicePayments(ctx context.Context, params *GetInvoicePayme
 		params = NewGetInvoicePaymentsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1632,14 +1341,6 @@ func (a *Client) GetInvoicesForAccount(ctx context.Context, params *GetInvoicesF
 		params = NewGetInvoicesForAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1673,14 +1374,6 @@ func (a *Client) GetOverdueAccount(ctx context.Context, params *GetOverdueAccoun
 		params = NewGetOverdueAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1714,14 +1407,6 @@ func (a *Client) GetPaymentMethodsForAccount(ctx context.Context, params *GetPay
 		params = NewGetPaymentMethodsForAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1755,14 +1440,6 @@ func (a *Client) GetPaymentsForAccount(ctx context.Context, params *GetPaymentsF
 		params = NewGetPaymentsForAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1796,14 +1473,6 @@ func (a *Client) ModifyAccountCustomFields(ctx context.Context, params *ModifyAc
 		params = NewModifyAccountCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1849,14 +1518,6 @@ func (a *Client) PayAllInvoices(ctx context.Context, params *PayAllInvoicesParam
 		params = NewPayAllInvoicesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1904,31 +1565,18 @@ func (a *Client) ProcessPayment(ctx context.Context, params *ProcessPaymentParam
 	getParams := NewProcessPaymentParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1987,31 +1635,18 @@ func (a *Client) ProcessPaymentByExternalKey(ctx context.Context, params *Proces
 	getParams := NewProcessPaymentByExternalKeyParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -2068,14 +1703,6 @@ func (a *Client) RebalanceExistingCBAOnAccount(ctx context.Context, params *Reba
 		params = NewRebalanceExistingCBAOnAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -2121,14 +1748,6 @@ func (a *Client) RefreshPaymentMethods(ctx context.Context, params *RefreshPayme
 		params = NewRefreshPaymentMethodsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -2174,14 +1793,6 @@ func (a *Client) RemoveEmail(ctx context.Context, params *RemoveEmailParams) (*R
 		params = NewRemoveEmailParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -2227,14 +1838,6 @@ func (a *Client) SearchAccounts(ctx context.Context, params *SearchAccountsParam
 		params = NewSearchAccountsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -2268,14 +1871,6 @@ func (a *Client) SetDefaultPaymentMethod(ctx context.Context, params *SetDefault
 		params = NewSetDefaultPaymentMethodParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -2313,59 +1908,6 @@ func (a *Client) SetDefaultPaymentMethod(ctx context.Context, params *SetDefault
 }
 
 /*
-SetEmailNotificationsForAccount sets account email notification
-*/
-func (a *Client) SetEmailNotificationsForAccount(ctx context.Context, params *SetEmailNotificationsForAccountParams) (*SetEmailNotificationsForAccountNoContent, error) {
-	// TODO: Validate the params before sending
-	if params == nil {
-		params = NewSetEmailNotificationsForAccountParams()
-	}
-	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
-	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
-		params.XKillbillComment = a.defaults.XKillbillComment()
-	}
-
-	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
-		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
-	}
-
-	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
-		params.XKillbillReason = a.defaults.XKillbillReason()
-	}
-
-	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
-		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
-	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
-		ID:                 "setEmailNotificationsForAccount",
-		Method:             "PUT",
-		PathPattern:        "/1.0/kb/accounts/{accountId}/emailNotifications",
-		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"http"},
-		Params:             params,
-		Reader:             &SetEmailNotificationsForAccountReader{formats: a.formats},
-		AuthInfo:           a.authInfo,
-		Context:            params.Context,
-		Client:             params.HTTPClient,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result.(*SetEmailNotificationsForAccountNoContent), nil
-
-}
-
-/*
 TransferChildCreditToParent moves a given child credit to the parent level
 */
 func (a *Client) TransferChildCreditToParent(ctx context.Context, params *TransferChildCreditToParentParams) (*TransferChildCreditToParentNoContent, error) {
@@ -2374,14 +1916,6 @@ func (a *Client) TransferChildCreditToParent(ctx context.Context, params *Transf
 		params = NewTransferChildCreditToParentParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -2427,14 +1961,6 @@ func (a *Client) UpdateAccount(ctx context.Context, params *UpdateAccountParams)
 		params = NewUpdateAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/account/add_account_blocking_state_parameters.go
+++ b/kbclient/account/add_account_blocking_state_parameters.go
@@ -65,10 +65,6 @@ for the add account blocking state operation typically these are written to a ht
 */
 type AddAccountBlockingStateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *AddAccountBlockingStateParams) WithHTTPClient(client *http.Client) *Add
 // SetHTTPClient adds the HTTPClient to the add account blocking state params
 func (o *AddAccountBlockingStateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the add account blocking state params
-func (o *AddAccountBlockingStateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *AddAccountBlockingStateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the add account blocking state params
-func (o *AddAccountBlockingStateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the add account blocking state params
-func (o *AddAccountBlockingStateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *AddAccountBlockingStateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the add account blocking state params
-func (o *AddAccountBlockingStateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the add account blocking state params
@@ -230,16 +204,6 @@ func (o *AddAccountBlockingStateParams) WriteToRequest(r runtime.ClientRequest, 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/add_email_parameters.go
+++ b/kbclient/account/add_email_parameters.go
@@ -64,10 +64,6 @@ for the add email operation typically these are written to a http.Request
 */
 type AddEmailParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *AddEmailParams) WithHTTPClient(client *http.Client) *AddEmailParams {
 // SetHTTPClient adds the HTTPClient to the add email params
 func (o *AddEmailParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the add email params
-func (o *AddEmailParams) WithXKillbillAPIKey(xKillbillAPIKey string) *AddEmailParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the add email params
-func (o *AddEmailParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the add email params
-func (o *AddEmailParams) WithXKillbillAPISecret(xKillbillAPISecret string) *AddEmailParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the add email params
-func (o *AddEmailParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the add email params
@@ -203,16 +177,6 @@ func (o *AddEmailParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/close_account_parameters.go
+++ b/kbclient/account/close_account_parameters.go
@@ -99,10 +99,6 @@ for the close account operation typically these are written to a http.Request
 */
 type CloseAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -158,28 +154,6 @@ func (o *CloseAccountParams) WithHTTPClient(client *http.Client) *CloseAccountPa
 // SetHTTPClient adds the HTTPClient to the close account params
 func (o *CloseAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the close account params
-func (o *CloseAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CloseAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the close account params
-func (o *CloseAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the close account params
-func (o *CloseAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CloseAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the close account params
-func (o *CloseAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the close account params
@@ -277,16 +251,6 @@ func (o *CloseAccountParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/create_account_custom_fields_parameters.go
+++ b/kbclient/account/create_account_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create account custom fields operation typically these are written to a 
 */
 type CreateAccountCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreateAccountCustomFieldsParams) WithHTTPClient(client *http.Client) *C
 // SetHTTPClient adds the HTTPClient to the create account custom fields params
 func (o *CreateAccountCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create account custom fields params
-func (o *CreateAccountCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateAccountCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create account custom fields params
-func (o *CreateAccountCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create account custom fields params
-func (o *CreateAccountCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateAccountCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create account custom fields params
-func (o *CreateAccountCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create account custom fields params
@@ -203,16 +177,6 @@ func (o *CreateAccountCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/create_account_parameters.go
+++ b/kbclient/account/create_account_parameters.go
@@ -64,10 +64,6 @@ for the create account operation typically these are written to a http.Request
 */
 type CreateAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateAccountParams) WithHTTPClient(client *http.Client) *CreateAccount
 // SetHTTPClient adds the HTTPClient to the create account params
 func (o *CreateAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create account params
-func (o *CreateAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create account params
-func (o *CreateAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create account params
-func (o *CreateAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create account params
-func (o *CreateAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create account params
@@ -190,16 +164,6 @@ func (o *CreateAccountParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/create_account_tags_parameters.go
+++ b/kbclient/account/create_account_tags_parameters.go
@@ -62,10 +62,6 @@ for the create account tags operation typically these are written to a http.Requ
 */
 type CreateAccountTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateAccountTagsParams) WithHTTPClient(client *http.Client) *CreateAcc
 // SetHTTPClient adds the HTTPClient to the create account tags params
 func (o *CreateAccountTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create account tags params
-func (o *CreateAccountTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateAccountTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create account tags params
-func (o *CreateAccountTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create account tags params
-func (o *CreateAccountTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateAccountTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create account tags params
-func (o *CreateAccountTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create account tags params
@@ -201,16 +175,6 @@ func (o *CreateAccountTagsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/create_payment_method_parameters.go
+++ b/kbclient/account/create_payment_method_parameters.go
@@ -85,10 +85,6 @@ for the create payment method operation typically these are written to a http.Re
 */
 type CreatePaymentMethodParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -146,28 +142,6 @@ func (o *CreatePaymentMethodParams) WithHTTPClient(client *http.Client) *CreateP
 // SetHTTPClient adds the HTTPClient to the create payment method params
 func (o *CreatePaymentMethodParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create payment method params
-func (o *CreatePaymentMethodParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreatePaymentMethodParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create payment method params
-func (o *CreatePaymentMethodParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create payment method params
-func (o *CreatePaymentMethodParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreatePaymentMethodParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create payment method params
-func (o *CreatePaymentMethodParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create payment method params
@@ -276,16 +250,6 @@ func (o *CreatePaymentMethodParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/delete_account_custom_fields_parameters.go
+++ b/kbclient/account/delete_account_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete account custom fields operation typically these are written to a 
 */
 type DeleteAccountCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteAccountCustomFieldsParams) WithHTTPClient(client *http.Client) *D
 // SetHTTPClient adds the HTTPClient to the delete account custom fields params
 func (o *DeleteAccountCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete account custom fields params
-func (o *DeleteAccountCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteAccountCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete account custom fields params
-func (o *DeleteAccountCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete account custom fields params
-func (o *DeleteAccountCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteAccountCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete account custom fields params
-func (o *DeleteAccountCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete account custom fields params
@@ -202,16 +176,6 @@ func (o *DeleteAccountCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/delete_account_tags_parameters.go
+++ b/kbclient/account/delete_account_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete account tags operation typically these are written to a http.Requ
 */
 type DeleteAccountTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteAccountTagsParams) WithHTTPClient(client *http.Client) *DeleteAcc
 // SetHTTPClient adds the HTTPClient to the delete account tags params
 func (o *DeleteAccountTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete account tags params
-func (o *DeleteAccountTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteAccountTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete account tags params
-func (o *DeleteAccountTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete account tags params
-func (o *DeleteAccountTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteAccountTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete account tags params
-func (o *DeleteAccountTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete account tags params
@@ -202,16 +176,6 @@ func (o *DeleteAccountTagsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/get_account_audit_logs_parameters.go
+++ b/kbclient/account/get_account_audit_logs_parameters.go
@@ -62,10 +62,6 @@ for the get account audit logs operation typically these are written to a http.R
 */
 type GetAccountAuditLogsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetAccountAuditLogsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account audit logs params
-func (o *GetAccountAuditLogsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountAuditLogsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account audit logs params
-func (o *GetAccountAuditLogsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account audit logs params
-func (o *GetAccountAuditLogsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountAuditLogsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account audit logs params
-func (o *GetAccountAuditLogsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get account audit logs params
 func (o *GetAccountAuditLogsParams) WithAccountID(accountID strfmt.UUID) *GetAccountAuditLogsParams {
 	o.SetAccountID(accountID)
@@ -149,16 +123,6 @@ func (o *GetAccountAuditLogsParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_account_audit_logs_with_history_parameters.go
+++ b/kbclient/account/get_account_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get account audit logs with history operation typically these are writte
 */
 type GetAccountAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetAccountAuditLogsWithHistoryParams) SetHTTPClient(client *http.Client
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account audit logs with history params
-func (o *GetAccountAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account audit logs with history params
-func (o *GetAccountAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account audit logs with history params
-func (o *GetAccountAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account audit logs with history params
-func (o *GetAccountAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get account audit logs with history params
 func (o *GetAccountAuditLogsWithHistoryParams) WithAccountID(accountID strfmt.UUID) *GetAccountAuditLogsWithHistoryParams {
 	o.SetAccountID(accountID)
@@ -149,16 +123,6 @@ func (o *GetAccountAuditLogsWithHistoryParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_account_bundles_parameters.go
+++ b/kbclient/account/get_account_bundles_parameters.go
@@ -74,10 +74,6 @@ for the get account bundles operation typically these are written to a http.Requ
 */
 type GetAccountBundlesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -125,28 +121,6 @@ func (o *GetAccountBundlesParams) WithHTTPClient(client *http.Client) *GetAccoun
 // SetHTTPClient adds the HTTPClient to the get account bundles params
 func (o *GetAccountBundlesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account bundles params
-func (o *GetAccountBundlesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountBundlesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account bundles params
-func (o *GetAccountBundlesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account bundles params
-func (o *GetAccountBundlesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountBundlesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account bundles params
-func (o *GetAccountBundlesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get account bundles params
@@ -200,16 +174,6 @@ func (o *GetAccountBundlesParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_account_by_key_parameters.go
+++ b/kbclient/account/get_account_by_key_parameters.go
@@ -91,10 +91,6 @@ for the get account by key operation typically these are written to a http.Reque
 */
 type GetAccountByKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountWithBalance*/
 	AccountWithBalance *bool
 	/*AccountWithBalanceAndCBA*/
@@ -142,28 +138,6 @@ func (o *GetAccountByKeyParams) WithHTTPClient(client *http.Client) *GetAccountB
 // SetHTTPClient adds the HTTPClient to the get account by key params
 func (o *GetAccountByKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account by key params
-func (o *GetAccountByKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountByKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account by key params
-func (o *GetAccountByKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account by key params
-func (o *GetAccountByKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountByKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account by key params
-func (o *GetAccountByKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountWithBalance adds the accountWithBalance to the get account by key params
@@ -217,16 +191,6 @@ func (o *GetAccountByKeyParams) WriteToRequest(r runtime.ClientRequest, reg strf
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountWithBalance != nil {
 

--- a/kbclient/account/get_account_custom_fields_parameters.go
+++ b/kbclient/account/get_account_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get account custom fields operation typically these are written to a htt
 */
 type GetAccountCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -123,28 +119,6 @@ func (o *GetAccountCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account custom fields params
-func (o *GetAccountCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account custom fields params
-func (o *GetAccountCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account custom fields params
-func (o *GetAccountCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account custom fields params
-func (o *GetAccountCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get account custom fields params
 func (o *GetAccountCustomFieldsParams) WithAccountID(accountID strfmt.UUID) *GetAccountCustomFieldsParams {
 	o.SetAccountID(accountID)
@@ -174,16 +148,6 @@ func (o *GetAccountCustomFieldsParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_account_email_audit_logs_with_history_parameters.go
+++ b/kbclient/account/get_account_email_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get account email audit logs with history operation typically these are 
 */
 type GetAccountEmailAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountEmailID*/
 	AccountEmailID strfmt.UUID
 	/*AccountID*/
@@ -111,28 +107,6 @@ func (o *GetAccountEmailAuditLogsWithHistoryParams) SetHTTPClient(client *http.C
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account email audit logs with history params
-func (o *GetAccountEmailAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountEmailAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account email audit logs with history params
-func (o *GetAccountEmailAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account email audit logs with history params
-func (o *GetAccountEmailAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountEmailAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account email audit logs with history params
-func (o *GetAccountEmailAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountEmailID adds the accountEmailID to the get account email audit logs with history params
 func (o *GetAccountEmailAuditLogsWithHistoryParams) WithAccountEmailID(accountEmailID strfmt.UUID) *GetAccountEmailAuditLogsWithHistoryParams {
 	o.SetAccountEmailID(accountEmailID)
@@ -162,16 +136,6 @@ func (o *GetAccountEmailAuditLogsWithHistoryParams) WriteToRequest(r runtime.Cli
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountEmailId
 	if err := r.SetPathParam("accountEmailId", o.AccountEmailID.String()); err != nil {

--- a/kbclient/account/get_account_parameters.go
+++ b/kbclient/account/get_account_parameters.go
@@ -91,10 +91,6 @@ for the get account operation typically these are written to a http.Request
 */
 type GetAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*AccountWithBalance*/
@@ -142,28 +138,6 @@ func (o *GetAccountParams) WithHTTPClient(client *http.Client) *GetAccountParams
 // SetHTTPClient adds the HTTPClient to the get account params
 func (o *GetAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account params
-func (o *GetAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account params
-func (o *GetAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account params
-func (o *GetAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account params
-func (o *GetAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get account params
@@ -217,16 +191,6 @@ func (o *GetAccountParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_account_tags_parameters.go
+++ b/kbclient/account/get_account_tags_parameters.go
@@ -83,10 +83,6 @@ for the get account tags operation typically these are written to a http.Request
 */
 type GetAccountTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -134,28 +130,6 @@ func (o *GetAccountTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account tags params
-func (o *GetAccountTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account tags params
-func (o *GetAccountTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account tags params
-func (o *GetAccountTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account tags params
-func (o *GetAccountTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get account tags params
 func (o *GetAccountTagsParams) WithAccountID(accountID strfmt.UUID) *GetAccountTagsParams {
 	o.SetAccountID(accountID)
@@ -196,16 +170,6 @@ func (o *GetAccountTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_account_timeline_parameters.go
+++ b/kbclient/account/get_account_timeline_parameters.go
@@ -83,10 +83,6 @@ for the get account timeline operation typically these are written to a http.Req
 */
 type GetAccountTimelineParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -134,28 +130,6 @@ func (o *GetAccountTimelineParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get account timeline params
-func (o *GetAccountTimelineParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountTimelineParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get account timeline params
-func (o *GetAccountTimelineParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get account timeline params
-func (o *GetAccountTimelineParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountTimelineParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get account timeline params
-func (o *GetAccountTimelineParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get account timeline params
 func (o *GetAccountTimelineParams) WithAccountID(accountID strfmt.UUID) *GetAccountTimelineParams {
 	o.SetAccountID(accountID)
@@ -196,16 +170,6 @@ func (o *GetAccountTimelineParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_accounts_parameters.go
+++ b/kbclient/account/get_accounts_parameters.go
@@ -107,10 +107,6 @@ for the get accounts operation typically these are written to a http.Request
 */
 type GetAccountsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountWithBalance*/
 	AccountWithBalance *bool
 	/*AccountWithBalanceAndCBA*/
@@ -160,28 +156,6 @@ func (o *GetAccountsParams) WithHTTPClient(client *http.Client) *GetAccountsPara
 // SetHTTPClient adds the HTTPClient to the get accounts params
 func (o *GetAccountsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get accounts params
-func (o *GetAccountsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAccountsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get accounts params
-func (o *GetAccountsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get accounts params
-func (o *GetAccountsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAccountsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get accounts params
-func (o *GetAccountsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountWithBalance adds the accountWithBalance to the get accounts params
@@ -246,16 +220,6 @@ func (o *GetAccountsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountWithBalance != nil {
 

--- a/kbclient/account/get_all_custom_fields_parameters.go
+++ b/kbclient/account/get_all_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get all custom fields operation typically these are written to a http.Re
 */
 type GetAllCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -125,28 +121,6 @@ func (o *GetAllCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get all custom fields params
-func (o *GetAllCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAllCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get all custom fields params
-func (o *GetAllCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get all custom fields params
-func (o *GetAllCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAllCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get all custom fields params
-func (o *GetAllCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get all custom fields params
 func (o *GetAllCustomFieldsParams) WithAccountID(accountID strfmt.UUID) *GetAllCustomFieldsParams {
 	o.SetAccountID(accountID)
@@ -187,16 +161,6 @@ func (o *GetAllCustomFieldsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_all_tags_parameters.go
+++ b/kbclient/account/get_all_tags_parameters.go
@@ -83,10 +83,6 @@ for the get all tags operation typically these are written to a http.Request
 */
 type GetAllTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -134,28 +130,6 @@ func (o *GetAllTagsParams) WithHTTPClient(client *http.Client) *GetAllTagsParams
 // SetHTTPClient adds the HTTPClient to the get all tags params
 func (o *GetAllTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get all tags params
-func (o *GetAllTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAllTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get all tags params
-func (o *GetAllTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get all tags params
-func (o *GetAllTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAllTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get all tags params
-func (o *GetAllTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get all tags params
@@ -209,16 +183,6 @@ func (o *GetAllTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_blocking_states_parameters.go
+++ b/kbclient/account/get_blocking_states_parameters.go
@@ -75,10 +75,6 @@ for the get blocking states operation typically these are written to a http.Requ
 */
 type GetBlockingStatesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -126,28 +122,6 @@ func (o *GetBlockingStatesParams) WithHTTPClient(client *http.Client) *GetBlocki
 // SetHTTPClient adds the HTTPClient to the get blocking states params
 func (o *GetBlockingStatesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get blocking states params
-func (o *GetBlockingStatesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetBlockingStatesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get blocking states params
-func (o *GetBlockingStatesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get blocking states params
-func (o *GetBlockingStatesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetBlockingStatesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get blocking states params
-func (o *GetBlockingStatesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get blocking states params
@@ -201,16 +175,6 @@ func (o *GetBlockingStatesParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_children_accounts_parameters.go
+++ b/kbclient/account/get_children_accounts_parameters.go
@@ -91,10 +91,6 @@ for the get children accounts operation typically these are written to a http.Re
 */
 type GetChildrenAccountsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*AccountWithBalance*/
@@ -142,28 +138,6 @@ func (o *GetChildrenAccountsParams) WithHTTPClient(client *http.Client) *GetChil
 // SetHTTPClient adds the HTTPClient to the get children accounts params
 func (o *GetChildrenAccountsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get children accounts params
-func (o *GetChildrenAccountsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetChildrenAccountsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get children accounts params
-func (o *GetChildrenAccountsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get children accounts params
-func (o *GetChildrenAccountsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetChildrenAccountsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get children accounts params
-func (o *GetChildrenAccountsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get children accounts params
@@ -217,16 +191,6 @@ func (o *GetChildrenAccountsParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_emails_parameters.go
+++ b/kbclient/account/get_emails_parameters.go
@@ -62,10 +62,6 @@ for the get emails operation typically these are written to a http.Request
 */
 type GetEmailsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetEmailsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get emails params
-func (o *GetEmailsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetEmailsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get emails params
-func (o *GetEmailsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get emails params
-func (o *GetEmailsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetEmailsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get emails params
-func (o *GetEmailsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get emails params
 func (o *GetEmailsParams) WithAccountID(accountID strfmt.UUID) *GetEmailsParams {
 	o.SetAccountID(accountID)
@@ -149,16 +123,6 @@ func (o *GetEmailsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_invoice_payments_parameters.go
+++ b/kbclient/account/get_invoice_payments_parameters.go
@@ -91,10 +91,6 @@ for the get invoice payments operation typically these are written to a http.Req
 */
 type GetInvoicePaymentsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -144,28 +140,6 @@ func (o *GetInvoicePaymentsParams) WithHTTPClient(client *http.Client) *GetInvoi
 // SetHTTPClient adds the HTTPClient to the get invoice payments params
 func (o *GetInvoicePaymentsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice payments params
-func (o *GetInvoicePaymentsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoicePaymentsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice payments params
-func (o *GetInvoicePaymentsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice payments params
-func (o *GetInvoicePaymentsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoicePaymentsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice payments params
-func (o *GetInvoicePaymentsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get invoice payments params
@@ -230,16 +204,6 @@ func (o *GetInvoicePaymentsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_invoices_for_account_parameters.go
+++ b/kbclient/account/get_invoices_for_account_parameters.go
@@ -107,10 +107,6 @@ for the get invoices for account operation typically these are written to a http
 */
 type GetInvoicesForAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -164,28 +160,6 @@ func (o *GetInvoicesForAccountParams) WithHTTPClient(client *http.Client) *GetIn
 // SetHTTPClient adds the HTTPClient to the get invoices for account params
 func (o *GetInvoicesForAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoices for account params
-func (o *GetInvoicesForAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoicesForAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoices for account params
-func (o *GetInvoicesForAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoices for account params
-func (o *GetInvoicesForAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoicesForAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoices for account params
-func (o *GetInvoicesForAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get invoices for account params
@@ -272,16 +246,6 @@ func (o *GetInvoicesForAccountParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_overdue_account_parameters.go
+++ b/kbclient/account/get_overdue_account_parameters.go
@@ -62,10 +62,6 @@ for the get overdue account operation typically these are written to a http.Requ
 */
 type GetOverdueAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetOverdueAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get overdue account params
-func (o *GetOverdueAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetOverdueAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get overdue account params
-func (o *GetOverdueAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get overdue account params
-func (o *GetOverdueAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetOverdueAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get overdue account params
-func (o *GetOverdueAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get overdue account params
 func (o *GetOverdueAccountParams) WithAccountID(accountID strfmt.UUID) *GetOverdueAccountParams {
 	o.SetAccountID(accountID)
@@ -149,16 +123,6 @@ func (o *GetOverdueAccountParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_payment_methods_for_account_parameters.go
+++ b/kbclient/account/get_payment_methods_for_account_parameters.go
@@ -91,10 +91,6 @@ for the get payment methods for account operation typically these are written to
 */
 type GetPaymentMethodsForAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -144,28 +140,6 @@ func (o *GetPaymentMethodsForAccountParams) WithHTTPClient(client *http.Client) 
 // SetHTTPClient adds the HTTPClient to the get payment methods for account params
 func (o *GetPaymentMethodsForAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment methods for account params
-func (o *GetPaymentMethodsForAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentMethodsForAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment methods for account params
-func (o *GetPaymentMethodsForAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment methods for account params
-func (o *GetPaymentMethodsForAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentMethodsForAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment methods for account params
-func (o *GetPaymentMethodsForAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get payment methods for account params
@@ -230,16 +204,6 @@ func (o *GetPaymentMethodsForAccountParams) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/get_payments_for_account_parameters.go
+++ b/kbclient/account/get_payments_for_account_parameters.go
@@ -91,10 +91,6 @@ for the get payments for account operation typically these are written to a http
 */
 type GetPaymentsForAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -144,28 +140,6 @@ func (o *GetPaymentsForAccountParams) WithHTTPClient(client *http.Client) *GetPa
 // SetHTTPClient adds the HTTPClient to the get payments for account params
 func (o *GetPaymentsForAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payments for account params
-func (o *GetPaymentsForAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentsForAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payments for account params
-func (o *GetPaymentsForAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payments for account params
-func (o *GetPaymentsForAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentsForAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payments for account params
-func (o *GetPaymentsForAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get payments for account params
@@ -230,16 +204,6 @@ func (o *GetPaymentsForAccountParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/account/modify_account_custom_fields_parameters.go
+++ b/kbclient/account/modify_account_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify account custom fields operation typically these are written to a 
 */
 type ModifyAccountCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyAccountCustomFieldsParams) WithHTTPClient(client *http.Client) *M
 // SetHTTPClient adds the HTTPClient to the modify account custom fields params
 func (o *ModifyAccountCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify account custom fields params
-func (o *ModifyAccountCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyAccountCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify account custom fields params
-func (o *ModifyAccountCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify account custom fields params
-func (o *ModifyAccountCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyAccountCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify account custom fields params
-func (o *ModifyAccountCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify account custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyAccountCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/pay_all_invoices_parameters.go
+++ b/kbclient/account/pay_all_invoices_parameters.go
@@ -75,10 +75,6 @@ for the pay all invoices operation typically these are written to a http.Request
 */
 type PayAllInvoicesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -136,28 +132,6 @@ func (o *PayAllInvoicesParams) WithHTTPClient(client *http.Client) *PayAllInvoic
 // SetHTTPClient adds the HTTPClient to the pay all invoices params
 func (o *PayAllInvoicesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the pay all invoices params
-func (o *PayAllInvoicesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *PayAllInvoicesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the pay all invoices params
-func (o *PayAllInvoicesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the pay all invoices params
-func (o *PayAllInvoicesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *PayAllInvoicesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the pay all invoices params
-func (o *PayAllInvoicesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the pay all invoices params
@@ -266,16 +240,6 @@ func (o *PayAllInvoicesParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/process_payment_by_external_key_parameters.go
+++ b/kbclient/account/process_payment_by_external_key_parameters.go
@@ -65,10 +65,6 @@ for the process payment by external key operation typically these are written to
 */
 type ProcessPaymentByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -124,28 +120,6 @@ func (o *ProcessPaymentByExternalKeyParams) WithHTTPClient(client *http.Client) 
 // SetHTTPClient adds the HTTPClient to the process payment by external key params
 func (o *ProcessPaymentByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the process payment by external key params
-func (o *ProcessPaymentByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ProcessPaymentByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the process payment by external key params
-func (o *ProcessPaymentByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the process payment by external key params
-func (o *ProcessPaymentByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ProcessPaymentByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the process payment by external key params
-func (o *ProcessPaymentByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the process payment by external key params
@@ -243,16 +217,6 @@ func (o *ProcessPaymentByExternalKeyParams) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/process_payment_parameters.go
+++ b/kbclient/account/process_payment_parameters.go
@@ -65,10 +65,6 @@ for the process payment operation typically these are written to a http.Request
 */
 type ProcessPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -124,28 +120,6 @@ func (o *ProcessPaymentParams) WithHTTPClient(client *http.Client) *ProcessPayme
 // SetHTTPClient adds the HTTPClient to the process payment params
 func (o *ProcessPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the process payment params
-func (o *ProcessPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ProcessPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the process payment params
-func (o *ProcessPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the process payment params
-func (o *ProcessPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ProcessPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the process payment params
-func (o *ProcessPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the process payment params
@@ -243,16 +217,6 @@ func (o *ProcessPaymentParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/rebalance_existing_c_b_a_on_account_parameters.go
+++ b/kbclient/account/rebalance_existing_c_b_a_on_account_parameters.go
@@ -62,10 +62,6 @@ for the rebalance existing c b a on account operation typically these are writte
 */
 type RebalanceExistingCBAOnAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *RebalanceExistingCBAOnAccountParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the rebalance existing c b a on account params
 func (o *RebalanceExistingCBAOnAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the rebalance existing c b a on account params
-func (o *RebalanceExistingCBAOnAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RebalanceExistingCBAOnAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the rebalance existing c b a on account params
-func (o *RebalanceExistingCBAOnAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the rebalance existing c b a on account params
-func (o *RebalanceExistingCBAOnAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RebalanceExistingCBAOnAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the rebalance existing c b a on account params
-func (o *RebalanceExistingCBAOnAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the rebalance existing c b a on account params
@@ -188,16 +162,6 @@ func (o *RebalanceExistingCBAOnAccountParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/refresh_payment_methods_parameters.go
+++ b/kbclient/account/refresh_payment_methods_parameters.go
@@ -63,10 +63,6 @@ for the refresh payment methods operation typically these are written to a http.
 */
 type RefreshPaymentMethodsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -118,28 +114,6 @@ func (o *RefreshPaymentMethodsParams) WithHTTPClient(client *http.Client) *Refre
 // SetHTTPClient adds the HTTPClient to the refresh payment methods params
 func (o *RefreshPaymentMethodsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the refresh payment methods params
-func (o *RefreshPaymentMethodsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RefreshPaymentMethodsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the refresh payment methods params
-func (o *RefreshPaymentMethodsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the refresh payment methods params
-func (o *RefreshPaymentMethodsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RefreshPaymentMethodsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the refresh payment methods params
-func (o *RefreshPaymentMethodsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the refresh payment methods params
@@ -215,16 +189,6 @@ func (o *RefreshPaymentMethodsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/remove_email_parameters.go
+++ b/kbclient/account/remove_email_parameters.go
@@ -62,10 +62,6 @@ for the remove email operation typically these are written to a http.Request
 */
 type RemoveEmailParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *RemoveEmailParams) WithHTTPClient(client *http.Client) *RemoveEmailPara
 // SetHTTPClient adds the HTTPClient to the remove email params
 func (o *RemoveEmailParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the remove email params
-func (o *RemoveEmailParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RemoveEmailParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the remove email params
-func (o *RemoveEmailParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the remove email params
-func (o *RemoveEmailParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RemoveEmailParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the remove email params
-func (o *RemoveEmailParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the remove email params
@@ -201,16 +175,6 @@ func (o *RemoveEmailParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/search_accounts_parameters.go
+++ b/kbclient/account/search_accounts_parameters.go
@@ -107,10 +107,6 @@ for the search accounts operation typically these are written to a http.Request
 */
 type SearchAccountsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountWithBalance*/
 	AccountWithBalance *bool
 	/*AccountWithBalanceAndCBA*/
@@ -162,28 +158,6 @@ func (o *SearchAccountsParams) WithHTTPClient(client *http.Client) *SearchAccoun
 // SetHTTPClient adds the HTTPClient to the search accounts params
 func (o *SearchAccountsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the search accounts params
-func (o *SearchAccountsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SearchAccountsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the search accounts params
-func (o *SearchAccountsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the search accounts params
-func (o *SearchAccountsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SearchAccountsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the search accounts params
-func (o *SearchAccountsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountWithBalance adds the accountWithBalance to the search accounts params
@@ -259,16 +233,6 @@ func (o *SearchAccountsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountWithBalance != nil {
 

--- a/kbclient/account/set_default_payment_method_parameters.go
+++ b/kbclient/account/set_default_payment_method_parameters.go
@@ -75,10 +75,6 @@ for the set default payment method operation typically these are written to a ht
 */
 type SetDefaultPaymentMethodParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -132,28 +128,6 @@ func (o *SetDefaultPaymentMethodParams) WithHTTPClient(client *http.Client) *Set
 // SetHTTPClient adds the HTTPClient to the set default payment method params
 func (o *SetDefaultPaymentMethodParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the set default payment method params
-func (o *SetDefaultPaymentMethodParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SetDefaultPaymentMethodParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the set default payment method params
-func (o *SetDefaultPaymentMethodParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the set default payment method params
-func (o *SetDefaultPaymentMethodParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SetDefaultPaymentMethodParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the set default payment method params
-func (o *SetDefaultPaymentMethodParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the set default payment method params
@@ -240,16 +214,6 @@ func (o *SetDefaultPaymentMethodParams) WriteToRequest(r runtime.ClientRequest, 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/transfer_child_credit_to_parent_parameters.go
+++ b/kbclient/account/transfer_child_credit_to_parent_parameters.go
@@ -62,10 +62,6 @@ for the transfer child credit to parent operation typically these are written to
 */
 type TransferChildCreditToParentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *TransferChildCreditToParentParams) WithHTTPClient(client *http.Client) 
 // SetHTTPClient adds the HTTPClient to the transfer child credit to parent params
 func (o *TransferChildCreditToParentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the transfer child credit to parent params
-func (o *TransferChildCreditToParentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *TransferChildCreditToParentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the transfer child credit to parent params
-func (o *TransferChildCreditToParentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the transfer child credit to parent params
-func (o *TransferChildCreditToParentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *TransferChildCreditToParentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the transfer child credit to parent params
-func (o *TransferChildCreditToParentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the transfer child credit to parent params
@@ -188,16 +162,6 @@ func (o *TransferChildCreditToParentParams) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/account/update_account_parameters.go
+++ b/kbclient/account/update_account_parameters.go
@@ -77,10 +77,6 @@ for the update account operation typically these are written to a http.Request
 */
 type UpdateAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -132,28 +128,6 @@ func (o *UpdateAccountParams) WithHTTPClient(client *http.Client) *UpdateAccount
 // SetHTTPClient adds the HTTPClient to the update account params
 func (o *UpdateAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the update account params
-func (o *UpdateAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UpdateAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the update account params
-func (o *UpdateAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the update account params
-func (o *UpdateAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UpdateAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the update account params
-func (o *UpdateAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the update account params
@@ -229,16 +203,6 @@ func (o *UpdateAccountParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/admin/admin_client.go
+++ b/kbclient/admin/admin_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -101,14 +97,6 @@ func (a *Client) GetQueueEntries(ctx context.Context, params *GetQueueEntriesPar
 		params = NewGetQueueEntriesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -142,14 +130,6 @@ func (a *Client) InvalidatesCache(ctx context.Context, params *InvalidatesCacheP
 		params = NewInvalidatesCacheParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -183,14 +163,6 @@ func (a *Client) InvalidatesCacheByAccount(ctx context.Context, params *Invalida
 		params = NewInvalidatesCacheByAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -224,14 +196,6 @@ func (a *Client) InvalidatesCacheByTenant(ctx context.Context, params *Invalidat
 		params = NewInvalidatesCacheByTenantParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -265,14 +229,6 @@ func (a *Client) PutInRotation(ctx context.Context, params *PutInRotationParams)
 		params = NewPutInRotationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -306,14 +262,6 @@ func (a *Client) PutOutOfRotation(ctx context.Context, params *PutOutOfRotationP
 		params = NewPutOutOfRotationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -347,14 +295,6 @@ func (a *Client) TriggerInvoiceGenerationForParkedAccounts(ctx context.Context, 
 		params = NewTriggerInvoiceGenerationForParkedAccountsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -400,14 +340,6 @@ func (a *Client) UpdatePaymentTransactionState(ctx context.Context, params *Upda
 		params = NewUpdatePaymentTransactionStateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/admin/get_queue_entries_parameters.go
+++ b/kbclient/admin/get_queue_entries_parameters.go
@@ -99,10 +99,6 @@ for the get queue entries operation typically these are written to a http.Reques
 */
 type GetQueueEntriesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID *strfmt.UUID
 	/*MaxDate*/
@@ -160,28 +156,6 @@ func (o *GetQueueEntriesParams) WithHTTPClient(client *http.Client) *GetQueueEnt
 // SetHTTPClient adds the HTTPClient to the get queue entries params
 func (o *GetQueueEntriesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get queue entries params
-func (o *GetQueueEntriesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetQueueEntriesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get queue entries params
-func (o *GetQueueEntriesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get queue entries params
-func (o *GetQueueEntriesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetQueueEntriesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get queue entries params
-func (o *GetQueueEntriesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get queue entries params
@@ -290,16 +264,6 @@ func (o *GetQueueEntriesParams) WriteToRequest(r runtime.ClientRequest, reg strf
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountID != nil {
 

--- a/kbclient/admin/invalidates_cache_by_account_parameters.go
+++ b/kbclient/admin/invalidates_cache_by_account_parameters.go
@@ -62,10 +62,6 @@ for the invalidates cache by account operation typically these are written to a 
 */
 type InvalidatesCacheByAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *InvalidatesCacheByAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the invalidates cache by account params
-func (o *InvalidatesCacheByAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *InvalidatesCacheByAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the invalidates cache by account params
-func (o *InvalidatesCacheByAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the invalidates cache by account params
-func (o *InvalidatesCacheByAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *InvalidatesCacheByAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the invalidates cache by account params
-func (o *InvalidatesCacheByAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the invalidates cache by account params
 func (o *InvalidatesCacheByAccountParams) WithAccountID(accountID strfmt.UUID) *InvalidatesCacheByAccountParams {
 	o.SetAccountID(accountID)
@@ -149,16 +123,6 @@ func (o *InvalidatesCacheByAccountParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param accountId
 	if err := r.SetPathParam("accountId", o.AccountID.String()); err != nil {

--- a/kbclient/admin/invalidates_cache_by_tenant_parameters.go
+++ b/kbclient/admin/invalidates_cache_by_tenant_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewInvalidatesCacheByTenantParams creates a new InvalidatesCacheByTenantParams object
 // with the default values initialized.
 func NewInvalidatesCacheByTenantParams() *InvalidatesCacheByTenantParams {
-	var ()
+
 	return &InvalidatesCacheByTenantParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewInvalidatesCacheByTenantParams() *InvalidatesCacheByTenantParams {
 // NewInvalidatesCacheByTenantParamsWithTimeout creates a new InvalidatesCacheByTenantParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewInvalidatesCacheByTenantParamsWithTimeout(timeout time.Duration) *InvalidatesCacheByTenantParams {
-	var ()
+
 	return &InvalidatesCacheByTenantParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewInvalidatesCacheByTenantParamsWithTimeout(timeout time.Duration) *Invali
 // NewInvalidatesCacheByTenantParamsWithContext creates a new InvalidatesCacheByTenantParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewInvalidatesCacheByTenantParamsWithContext(ctx context.Context) *InvalidatesCacheByTenantParams {
-	var ()
+
 	return &InvalidatesCacheByTenantParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewInvalidatesCacheByTenantParamsWithContext(ctx context.Context) *Invalida
 // NewInvalidatesCacheByTenantParamsWithHTTPClient creates a new InvalidatesCacheByTenantParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewInvalidatesCacheByTenantParamsWithHTTPClient(client *http.Client) *InvalidatesCacheByTenantParams {
-	var ()
+
 	return &InvalidatesCacheByTenantParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewInvalidatesCacheByTenantParamsWithHTTPClient(client *http.Client) *Inval
 for the invalidates cache by tenant operation typically these are written to a http.Request
 */
 type InvalidatesCacheByTenantParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *InvalidatesCacheByTenantParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the invalidates cache by tenant params
-func (o *InvalidatesCacheByTenantParams) WithXKillbillAPIKey(xKillbillAPIKey string) *InvalidatesCacheByTenantParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the invalidates cache by tenant params
-func (o *InvalidatesCacheByTenantParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the invalidates cache by tenant params
-func (o *InvalidatesCacheByTenantParams) WithXKillbillAPISecret(xKillbillAPISecret string) *InvalidatesCacheByTenantParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the invalidates cache by tenant params
-func (o *InvalidatesCacheByTenantParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *InvalidatesCacheByTenantParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *InvalidatesCacheByTenantParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/admin/invalidates_cache_parameters.go
+++ b/kbclient/admin/invalidates_cache_parameters.go
@@ -62,10 +62,6 @@ for the invalidates cache operation typically these are written to a http.Reques
 */
 type InvalidatesCacheParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*CacheName*/
 	CacheName *string
 
@@ -109,28 +105,6 @@ func (o *InvalidatesCacheParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the invalidates cache params
-func (o *InvalidatesCacheParams) WithXKillbillAPIKey(xKillbillAPIKey string) *InvalidatesCacheParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the invalidates cache params
-func (o *InvalidatesCacheParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the invalidates cache params
-func (o *InvalidatesCacheParams) WithXKillbillAPISecret(xKillbillAPISecret string) *InvalidatesCacheParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the invalidates cache params
-func (o *InvalidatesCacheParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithCacheName adds the cacheName to the invalidates cache params
 func (o *InvalidatesCacheParams) WithCacheName(cacheName *string) *InvalidatesCacheParams {
 	o.SetCacheName(cacheName)
@@ -149,16 +123,6 @@ func (o *InvalidatesCacheParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.CacheName != nil {
 

--- a/kbclient/admin/put_in_rotation_parameters.go
+++ b/kbclient/admin/put_in_rotation_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewPutInRotationParams creates a new PutInRotationParams object
 // with the default values initialized.
 func NewPutInRotationParams() *PutInRotationParams {
-	var ()
+
 	return &PutInRotationParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewPutInRotationParams() *PutInRotationParams {
 // NewPutInRotationParamsWithTimeout creates a new PutInRotationParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewPutInRotationParamsWithTimeout(timeout time.Duration) *PutInRotationParams {
-	var ()
+
 	return &PutInRotationParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewPutInRotationParamsWithTimeout(timeout time.Duration) *PutInRotationPara
 // NewPutInRotationParamsWithContext creates a new PutInRotationParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewPutInRotationParamsWithContext(ctx context.Context) *PutInRotationParams {
-	var ()
+
 	return &PutInRotationParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewPutInRotationParamsWithContext(ctx context.Context) *PutInRotationParams
 // NewPutInRotationParamsWithHTTPClient creates a new PutInRotationParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewPutInRotationParamsWithHTTPClient(client *http.Client) *PutInRotationParams {
-	var ()
+
 	return &PutInRotationParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewPutInRotationParamsWithHTTPClient(client *http.Client) *PutInRotationPar
 for the put in rotation operation typically these are written to a http.Request
 */
 type PutInRotationParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *PutInRotationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the put in rotation params
-func (o *PutInRotationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *PutInRotationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the put in rotation params
-func (o *PutInRotationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the put in rotation params
-func (o *PutInRotationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *PutInRotationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the put in rotation params
-func (o *PutInRotationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *PutInRotationParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *PutInRotationParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/admin/put_out_of_rotation_parameters.go
+++ b/kbclient/admin/put_out_of_rotation_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewPutOutOfRotationParams creates a new PutOutOfRotationParams object
 // with the default values initialized.
 func NewPutOutOfRotationParams() *PutOutOfRotationParams {
-	var ()
+
 	return &PutOutOfRotationParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewPutOutOfRotationParams() *PutOutOfRotationParams {
 // NewPutOutOfRotationParamsWithTimeout creates a new PutOutOfRotationParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewPutOutOfRotationParamsWithTimeout(timeout time.Duration) *PutOutOfRotationParams {
-	var ()
+
 	return &PutOutOfRotationParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewPutOutOfRotationParamsWithTimeout(timeout time.Duration) *PutOutOfRotati
 // NewPutOutOfRotationParamsWithContext creates a new PutOutOfRotationParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewPutOutOfRotationParamsWithContext(ctx context.Context) *PutOutOfRotationParams {
-	var ()
+
 	return &PutOutOfRotationParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewPutOutOfRotationParamsWithContext(ctx context.Context) *PutOutOfRotation
 // NewPutOutOfRotationParamsWithHTTPClient creates a new PutOutOfRotationParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewPutOutOfRotationParamsWithHTTPClient(client *http.Client) *PutOutOfRotationParams {
-	var ()
+
 	return &PutOutOfRotationParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewPutOutOfRotationParamsWithHTTPClient(client *http.Client) *PutOutOfRotat
 for the put out of rotation operation typically these are written to a http.Request
 */
 type PutOutOfRotationParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *PutOutOfRotationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the put out of rotation params
-func (o *PutOutOfRotationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *PutOutOfRotationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the put out of rotation params
-func (o *PutOutOfRotationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the put out of rotation params
-func (o *PutOutOfRotationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *PutOutOfRotationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the put out of rotation params
-func (o *PutOutOfRotationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *PutOutOfRotationParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *PutOutOfRotationParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/admin/trigger_invoice_generation_for_parked_accounts_parameters.go
+++ b/kbclient/admin/trigger_invoice_generation_for_parked_accounts_parameters.go
@@ -83,10 +83,6 @@ for the trigger invoice generation for parked accounts operation typically these
 */
 type TriggerInvoiceGenerationForParkedAccountsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -136,28 +132,6 @@ func (o *TriggerInvoiceGenerationForParkedAccountsParams) WithHTTPClient(client 
 // SetHTTPClient adds the HTTPClient to the trigger invoice generation for parked accounts params
 func (o *TriggerInvoiceGenerationForParkedAccountsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the trigger invoice generation for parked accounts params
-func (o *TriggerInvoiceGenerationForParkedAccountsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *TriggerInvoiceGenerationForParkedAccountsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the trigger invoice generation for parked accounts params
-func (o *TriggerInvoiceGenerationForParkedAccountsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the trigger invoice generation for parked accounts params
-func (o *TriggerInvoiceGenerationForParkedAccountsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *TriggerInvoiceGenerationForParkedAccountsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the trigger invoice generation for parked accounts params
-func (o *TriggerInvoiceGenerationForParkedAccountsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the trigger invoice generation for parked accounts params
@@ -222,16 +196,6 @@ func (o *TriggerInvoiceGenerationForParkedAccountsParams) WriteToRequest(r runti
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/admin/update_payment_transaction_state_parameters.go
+++ b/kbclient/admin/update_payment_transaction_state_parameters.go
@@ -64,10 +64,6 @@ for the update payment transaction state operation typically these are written t
 */
 type UpdatePaymentTransactionStateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -119,28 +115,6 @@ func (o *UpdatePaymentTransactionStateParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the update payment transaction state params
 func (o *UpdatePaymentTransactionStateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the update payment transaction state params
-func (o *UpdatePaymentTransactionStateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UpdatePaymentTransactionStateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the update payment transaction state params
-func (o *UpdatePaymentTransactionStateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the update payment transaction state params
-func (o *UpdatePaymentTransactionStateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UpdatePaymentTransactionStateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the update payment transaction state params
-func (o *UpdatePaymentTransactionStateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the update payment transaction state params
@@ -216,16 +190,6 @@ func (o *UpdatePaymentTransactionStateParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/add_bundle_blocking_state_parameters.go
+++ b/kbclient/bundle/add_bundle_blocking_state_parameters.go
@@ -65,10 +65,6 @@ for the add bundle blocking state operation typically these are written to a htt
 */
 type AddBundleBlockingStateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *AddBundleBlockingStateParams) WithHTTPClient(client *http.Client) *AddB
 // SetHTTPClient adds the HTTPClient to the add bundle blocking state params
 func (o *AddBundleBlockingStateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the add bundle blocking state params
-func (o *AddBundleBlockingStateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *AddBundleBlockingStateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the add bundle blocking state params
-func (o *AddBundleBlockingStateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the add bundle blocking state params
-func (o *AddBundleBlockingStateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *AddBundleBlockingStateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the add bundle blocking state params
-func (o *AddBundleBlockingStateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the add bundle blocking state params
@@ -230,16 +204,6 @@ func (o *AddBundleBlockingStateParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/bundle_client.go
+++ b/kbclient/bundle/bundle_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -144,31 +140,18 @@ func (a *Client) AddBundleBlockingState(ctx context.Context, params *AddBundleBl
 	getParams := NewAddBundleBlockingStateParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -227,31 +210,18 @@ func (a *Client) CreateBundleCustomFields(ctx context.Context, params *CreateBun
 	getParams := NewCreateBundleCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -310,31 +280,18 @@ func (a *Client) CreateBundleTags(ctx context.Context, params *CreateBundleTagsP
 	getParams := NewCreateBundleTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -391,14 +348,6 @@ func (a *Client) DeleteBundleCustomFields(ctx context.Context, params *DeleteBun
 		params = NewDeleteBundleCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -444,14 +393,6 @@ func (a *Client) DeleteBundleTags(ctx context.Context, params *DeleteBundleTagsP
 		params = NewDeleteBundleTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -497,14 +438,6 @@ func (a *Client) GetBundle(ctx context.Context, params *GetBundleParams) (*GetBu
 		params = NewGetBundleParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -538,14 +471,6 @@ func (a *Client) GetBundleByKey(ctx context.Context, params *GetBundleByKeyParam
 		params = NewGetBundleByKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -579,14 +504,6 @@ func (a *Client) GetBundleCustomFields(ctx context.Context, params *GetBundleCus
 		params = NewGetBundleCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -620,14 +537,6 @@ func (a *Client) GetBundleTags(ctx context.Context, params *GetBundleTagsParams)
 		params = NewGetBundleTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -661,14 +570,6 @@ func (a *Client) GetBundles(ctx context.Context, params *GetBundlesParams) (*Get
 		params = NewGetBundlesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -702,14 +603,6 @@ func (a *Client) ModifyBundleCustomFields(ctx context.Context, params *ModifyBun
 		params = NewModifyBundleCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -755,14 +648,6 @@ func (a *Client) PauseBundle(ctx context.Context, params *PauseBundleParams) (*P
 		params = NewPauseBundleParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -808,14 +693,6 @@ func (a *Client) RenameExternalKey(ctx context.Context, params *RenameExternalKe
 		params = NewRenameExternalKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -861,14 +738,6 @@ func (a *Client) ResumeBundle(ctx context.Context, params *ResumeBundleParams) (
 		params = NewResumeBundleParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -914,14 +783,6 @@ func (a *Client) SearchBundles(ctx context.Context, params *SearchBundlesParams)
 		params = NewSearchBundlesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -957,31 +818,18 @@ func (a *Client) TransferBundle(ctx context.Context, params *TransferBundleParam
 	getParams := NewTransferBundleParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/bundle/create_bundle_custom_fields_parameters.go
+++ b/kbclient/bundle/create_bundle_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create bundle custom fields operation typically these are written to a h
 */
 type CreateBundleCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreateBundleCustomFieldsParams) WithHTTPClient(client *http.Client) *Cr
 // SetHTTPClient adds the HTTPClient to the create bundle custom fields params
 func (o *CreateBundleCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create bundle custom fields params
-func (o *CreateBundleCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateBundleCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create bundle custom fields params
-func (o *CreateBundleCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create bundle custom fields params
-func (o *CreateBundleCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateBundleCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create bundle custom fields params
-func (o *CreateBundleCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create bundle custom fields params
@@ -203,16 +177,6 @@ func (o *CreateBundleCustomFieldsParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/create_bundle_tags_parameters.go
+++ b/kbclient/bundle/create_bundle_tags_parameters.go
@@ -62,10 +62,6 @@ for the create bundle tags operation typically these are written to a http.Reque
 */
 type CreateBundleTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateBundleTagsParams) WithHTTPClient(client *http.Client) *CreateBund
 // SetHTTPClient adds the HTTPClient to the create bundle tags params
 func (o *CreateBundleTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create bundle tags params
-func (o *CreateBundleTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateBundleTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create bundle tags params
-func (o *CreateBundleTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create bundle tags params
-func (o *CreateBundleTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateBundleTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create bundle tags params
-func (o *CreateBundleTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create bundle tags params
@@ -201,16 +175,6 @@ func (o *CreateBundleTagsParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/delete_bundle_custom_fields_parameters.go
+++ b/kbclient/bundle/delete_bundle_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete bundle custom fields operation typically these are written to a h
 */
 type DeleteBundleCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteBundleCustomFieldsParams) WithHTTPClient(client *http.Client) *De
 // SetHTTPClient adds the HTTPClient to the delete bundle custom fields params
 func (o *DeleteBundleCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete bundle custom fields params
-func (o *DeleteBundleCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteBundleCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete bundle custom fields params
-func (o *DeleteBundleCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete bundle custom fields params
-func (o *DeleteBundleCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteBundleCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete bundle custom fields params
-func (o *DeleteBundleCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete bundle custom fields params
@@ -202,16 +176,6 @@ func (o *DeleteBundleCustomFieldsParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/delete_bundle_tags_parameters.go
+++ b/kbclient/bundle/delete_bundle_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete bundle tags operation typically these are written to a http.Reque
 */
 type DeleteBundleTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteBundleTagsParams) WithHTTPClient(client *http.Client) *DeleteBund
 // SetHTTPClient adds the HTTPClient to the delete bundle tags params
 func (o *DeleteBundleTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete bundle tags params
-func (o *DeleteBundleTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteBundleTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete bundle tags params
-func (o *DeleteBundleTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete bundle tags params
-func (o *DeleteBundleTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteBundleTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete bundle tags params
-func (o *DeleteBundleTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete bundle tags params
@@ -202,16 +176,6 @@ func (o *DeleteBundleTagsParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/get_bundle_by_key_parameters.go
+++ b/kbclient/bundle/get_bundle_by_key_parameters.go
@@ -83,10 +83,6 @@ for the get bundle by key operation typically these are written to a http.Reques
 */
 type GetBundleByKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*ExternalKey*/
@@ -134,28 +130,6 @@ func (o *GetBundleByKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get bundle by key params
-func (o *GetBundleByKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetBundleByKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get bundle by key params
-func (o *GetBundleByKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get bundle by key params
-func (o *GetBundleByKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetBundleByKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get bundle by key params
-func (o *GetBundleByKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get bundle by key params
 func (o *GetBundleByKeyParams) WithAudit(audit *string) *GetBundleByKeyParams {
 	o.SetAudit(audit)
@@ -196,16 +170,6 @@ func (o *GetBundleByKeyParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/bundle/get_bundle_custom_fields_parameters.go
+++ b/kbclient/bundle/get_bundle_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get bundle custom fields operation typically these are written to a http
 */
 type GetBundleCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*BundleID*/
@@ -123,28 +119,6 @@ func (o *GetBundleCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get bundle custom fields params
-func (o *GetBundleCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetBundleCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get bundle custom fields params
-func (o *GetBundleCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get bundle custom fields params
-func (o *GetBundleCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetBundleCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get bundle custom fields params
-func (o *GetBundleCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get bundle custom fields params
 func (o *GetBundleCustomFieldsParams) WithAudit(audit *string) *GetBundleCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetBundleCustomFieldsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/bundle/get_bundle_parameters.go
+++ b/kbclient/bundle/get_bundle_parameters.go
@@ -74,10 +74,6 @@ for the get bundle operation typically these are written to a http.Request
 */
 type GetBundleParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*BundleID*/
@@ -123,28 +119,6 @@ func (o *GetBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get bundle params
-func (o *GetBundleParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetBundleParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get bundle params
-func (o *GetBundleParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get bundle params
-func (o *GetBundleParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetBundleParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get bundle params
-func (o *GetBundleParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get bundle params
 func (o *GetBundleParams) WithAudit(audit *string) *GetBundleParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/bundle/get_bundle_tags_parameters.go
+++ b/kbclient/bundle/get_bundle_tags_parameters.go
@@ -83,10 +83,6 @@ for the get bundle tags operation typically these are written to a http.Request
 */
 type GetBundleTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*BundleID*/
@@ -134,28 +130,6 @@ func (o *GetBundleTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get bundle tags params
-func (o *GetBundleTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetBundleTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get bundle tags params
-func (o *GetBundleTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get bundle tags params
-func (o *GetBundleTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetBundleTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get bundle tags params
-func (o *GetBundleTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get bundle tags params
 func (o *GetBundleTagsParams) WithAudit(audit *string) *GetBundleTagsParams {
 	o.SetAudit(audit)
@@ -196,16 +170,6 @@ func (o *GetBundleTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/bundle/get_bundles_parameters.go
+++ b/kbclient/bundle/get_bundles_parameters.go
@@ -91,10 +91,6 @@ for the get bundles operation typically these are written to a http.Request
 */
 type GetBundlesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -142,28 +138,6 @@ func (o *GetBundlesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get bundles params
-func (o *GetBundlesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetBundlesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get bundles params
-func (o *GetBundlesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get bundles params
-func (o *GetBundlesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetBundlesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get bundles params
-func (o *GetBundlesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get bundles params
 func (o *GetBundlesParams) WithAudit(audit *string) *GetBundlesParams {
 	o.SetAudit(audit)
@@ -204,16 +178,6 @@ func (o *GetBundlesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/bundle/modify_bundle_custom_fields_parameters.go
+++ b/kbclient/bundle/modify_bundle_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify bundle custom fields operation typically these are written to a h
 */
 type ModifyBundleCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyBundleCustomFieldsParams) WithHTTPClient(client *http.Client) *Mo
 // SetHTTPClient adds the HTTPClient to the modify bundle custom fields params
 func (o *ModifyBundleCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify bundle custom fields params
-func (o *ModifyBundleCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyBundleCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify bundle custom fields params
-func (o *ModifyBundleCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify bundle custom fields params
-func (o *ModifyBundleCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyBundleCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify bundle custom fields params
-func (o *ModifyBundleCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify bundle custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyBundleCustomFieldsParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/pause_bundle_parameters.go
+++ b/kbclient/bundle/pause_bundle_parameters.go
@@ -63,10 +63,6 @@ for the pause bundle operation typically these are written to a http.Request
 */
 type PauseBundleParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -118,28 +114,6 @@ func (o *PauseBundleParams) WithHTTPClient(client *http.Client) *PauseBundlePara
 // SetHTTPClient adds the HTTPClient to the pause bundle params
 func (o *PauseBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the pause bundle params
-func (o *PauseBundleParams) WithXKillbillAPIKey(xKillbillAPIKey string) *PauseBundleParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the pause bundle params
-func (o *PauseBundleParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the pause bundle params
-func (o *PauseBundleParams) WithXKillbillAPISecret(xKillbillAPISecret string) *PauseBundleParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the pause bundle params
-func (o *PauseBundleParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the pause bundle params
@@ -215,16 +189,6 @@ func (o *PauseBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/rename_external_key_parameters.go
+++ b/kbclient/bundle/rename_external_key_parameters.go
@@ -64,10 +64,6 @@ for the rename external key operation typically these are written to a http.Requ
 */
 type RenameExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *RenameExternalKeyParams) WithHTTPClient(client *http.Client) *RenameExt
 // SetHTTPClient adds the HTTPClient to the rename external key params
 func (o *RenameExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the rename external key params
-func (o *RenameExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RenameExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the rename external key params
-func (o *RenameExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the rename external key params
-func (o *RenameExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RenameExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the rename external key params
-func (o *RenameExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the rename external key params
@@ -203,16 +177,6 @@ func (o *RenameExternalKeyParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/resume_bundle_parameters.go
+++ b/kbclient/bundle/resume_bundle_parameters.go
@@ -63,10 +63,6 @@ for the resume bundle operation typically these are written to a http.Request
 */
 type ResumeBundleParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -118,28 +114,6 @@ func (o *ResumeBundleParams) WithHTTPClient(client *http.Client) *ResumeBundlePa
 // SetHTTPClient adds the HTTPClient to the resume bundle params
 func (o *ResumeBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the resume bundle params
-func (o *ResumeBundleParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ResumeBundleParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the resume bundle params
-func (o *ResumeBundleParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the resume bundle params
-func (o *ResumeBundleParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ResumeBundleParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the resume bundle params
-func (o *ResumeBundleParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the resume bundle params
@@ -215,16 +189,6 @@ func (o *ResumeBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/bundle/search_bundles_parameters.go
+++ b/kbclient/bundle/search_bundles_parameters.go
@@ -91,10 +91,6 @@ for the search bundles operation typically these are written to a http.Request
 */
 type SearchBundlesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -142,28 +138,6 @@ func (o *SearchBundlesParams) WithHTTPClient(client *http.Client) *SearchBundles
 // SetHTTPClient adds the HTTPClient to the search bundles params
 func (o *SearchBundlesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the search bundles params
-func (o *SearchBundlesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SearchBundlesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the search bundles params
-func (o *SearchBundlesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the search bundles params
-func (o *SearchBundlesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SearchBundlesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the search bundles params
-func (o *SearchBundlesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the search bundles params
@@ -217,16 +191,6 @@ func (o *SearchBundlesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/bundle/transfer_bundle_parameters.go
+++ b/kbclient/bundle/transfer_bundle_parameters.go
@@ -77,10 +77,6 @@ for the transfer bundle operation typically these are written to a http.Request
 */
 type TransferBundleParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -136,28 +132,6 @@ func (o *TransferBundleParams) WithHTTPClient(client *http.Client) *TransferBund
 // SetHTTPClient adds the HTTPClient to the transfer bundle params
 func (o *TransferBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the transfer bundle params
-func (o *TransferBundleParams) WithXKillbillAPIKey(xKillbillAPIKey string) *TransferBundleParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the transfer bundle params
-func (o *TransferBundleParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the transfer bundle params
-func (o *TransferBundleParams) WithXKillbillAPISecret(xKillbillAPISecret string) *TransferBundleParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the transfer bundle params
-func (o *TransferBundleParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the transfer bundle params
@@ -255,16 +229,6 @@ func (o *TransferBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/catalog/add_simple_plan_parameters.go
+++ b/kbclient/catalog/add_simple_plan_parameters.go
@@ -64,10 +64,6 @@ for the add simple plan operation typically these are written to a http.Request
 */
 type AddSimplePlanParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *AddSimplePlanParams) WithHTTPClient(client *http.Client) *AddSimplePlan
 // SetHTTPClient adds the HTTPClient to the add simple plan params
 func (o *AddSimplePlanParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the add simple plan params
-func (o *AddSimplePlanParams) WithXKillbillAPIKey(xKillbillAPIKey string) *AddSimplePlanParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the add simple plan params
-func (o *AddSimplePlanParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the add simple plan params
-func (o *AddSimplePlanParams) WithXKillbillAPISecret(xKillbillAPISecret string) *AddSimplePlanParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the add simple plan params
-func (o *AddSimplePlanParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the add simple plan params
@@ -190,16 +164,6 @@ func (o *AddSimplePlanParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/catalog/catalog_client.go
+++ b/kbclient/catalog/catalog_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -124,31 +120,18 @@ func (a *Client) AddSimplePlan(ctx context.Context, params *AddSimplePlanParams)
 	getParams := NewAddSimplePlanParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -205,14 +188,6 @@ func (a *Client) DeleteCatalog(ctx context.Context, params *DeleteCatalogParams)
 		params = NewDeleteCatalogParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -258,14 +233,6 @@ func (a *Client) GetAvailableAddons(ctx context.Context, params *GetAvailableAdd
 		params = NewGetAvailableAddonsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -299,14 +266,6 @@ func (a *Client) GetAvailableBasePlans(ctx context.Context, params *GetAvailable
 		params = NewGetAvailableBasePlansParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -340,14 +299,6 @@ func (a *Client) GetCatalogJSON(ctx context.Context, params *GetCatalogJSONParam
 		params = NewGetCatalogJSONParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -381,14 +332,6 @@ func (a *Client) GetCatalogVersions(ctx context.Context, params *GetCatalogVersi
 		params = NewGetCatalogVersionsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -422,14 +365,6 @@ func (a *Client) GetCatalogXML(ctx context.Context, params *GetCatalogXMLParams)
 		params = NewGetCatalogXMLParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -463,14 +398,6 @@ func (a *Client) GetPhaseForSubscriptionAndDate(ctx context.Context, params *Get
 		params = NewGetPhaseForSubscriptionAndDateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -504,14 +431,6 @@ func (a *Client) GetPlanForSubscriptionAndDate(ctx context.Context, params *GetP
 		params = NewGetPlanForSubscriptionAndDateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -545,14 +464,6 @@ func (a *Client) GetPriceListForSubscriptionAndDate(ctx context.Context, params 
 		params = NewGetPriceListForSubscriptionAndDateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -586,14 +497,6 @@ func (a *Client) GetProductForSubscriptionAndDate(ctx context.Context, params *G
 		params = NewGetProductForSubscriptionAndDateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -629,31 +532,18 @@ func (a *Client) UploadCatalogXML(ctx context.Context, params *UploadCatalogXMLP
 	getParams := NewUploadCatalogXMLParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/catalog/delete_catalog_parameters.go
+++ b/kbclient/catalog/delete_catalog_parameters.go
@@ -62,10 +62,6 @@ for the delete catalog operation typically these are written to a http.Request
 */
 type DeleteCatalogParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *DeleteCatalogParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete catalog params
-func (o *DeleteCatalogParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteCatalogParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete catalog params
-func (o *DeleteCatalogParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete catalog params
-func (o *DeleteCatalogParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteCatalogParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete catalog params
-func (o *DeleteCatalogParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithXKillbillComment adds the xKillbillComment to the delete catalog params
 func (o *DeleteCatalogParams) WithXKillbillComment(xKillbillComment *string) *DeleteCatalogParams {
 	o.SetXKillbillComment(xKillbillComment)
@@ -175,16 +149,6 @@ func (o *DeleteCatalogParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/catalog/get_available_addons_parameters.go
+++ b/kbclient/catalog/get_available_addons_parameters.go
@@ -62,10 +62,6 @@ for the get available addons operation typically these are written to a http.Req
 */
 type GetAvailableAddonsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID *strfmt.UUID
 	/*BaseProductName*/
@@ -113,28 +109,6 @@ func (o *GetAvailableAddonsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get available addons params
-func (o *GetAvailableAddonsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAvailableAddonsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get available addons params
-func (o *GetAvailableAddonsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get available addons params
-func (o *GetAvailableAddonsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAvailableAddonsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get available addons params
-func (o *GetAvailableAddonsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get available addons params
 func (o *GetAvailableAddonsParams) WithAccountID(accountID *strfmt.UUID) *GetAvailableAddonsParams {
 	o.SetAccountID(accountID)
@@ -175,16 +149,6 @@ func (o *GetAvailableAddonsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountID != nil {
 

--- a/kbclient/catalog/get_available_base_plans_parameters.go
+++ b/kbclient/catalog/get_available_base_plans_parameters.go
@@ -62,10 +62,6 @@ for the get available base plans operation typically these are written to a http
 */
 type GetAvailableBasePlansParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID *strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetAvailableBasePlansParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get available base plans params
-func (o *GetAvailableBasePlansParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAvailableBasePlansParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get available base plans params
-func (o *GetAvailableBasePlansParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get available base plans params
-func (o *GetAvailableBasePlansParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAvailableBasePlansParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get available base plans params
-func (o *GetAvailableBasePlansParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get available base plans params
 func (o *GetAvailableBasePlansParams) WithAccountID(accountID *strfmt.UUID) *GetAvailableBasePlansParams {
 	o.SetAccountID(accountID)
@@ -149,16 +123,6 @@ func (o *GetAvailableBasePlansParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountID != nil {
 

--- a/kbclient/catalog/get_catalog_json_parameters.go
+++ b/kbclient/catalog/get_catalog_json_parameters.go
@@ -62,10 +62,6 @@ for the get catalog Json operation typically these are written to a http.Request
 */
 type GetCatalogJSONParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID *strfmt.UUID
 	/*RequestedDate*/
@@ -111,28 +107,6 @@ func (o *GetCatalogJSONParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get catalog Json params
-func (o *GetCatalogJSONParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetCatalogJSONParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get catalog Json params
-func (o *GetCatalogJSONParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get catalog Json params
-func (o *GetCatalogJSONParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetCatalogJSONParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get catalog Json params
-func (o *GetCatalogJSONParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get catalog Json params
 func (o *GetCatalogJSONParams) WithAccountID(accountID *strfmt.UUID) *GetCatalogJSONParams {
 	o.SetAccountID(accountID)
@@ -162,16 +136,6 @@ func (o *GetCatalogJSONParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountID != nil {
 

--- a/kbclient/catalog/get_catalog_versions_parameters.go
+++ b/kbclient/catalog/get_catalog_versions_parameters.go
@@ -62,10 +62,6 @@ for the get catalog versions operation typically these are written to a http.Req
 */
 type GetCatalogVersionsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID *strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetCatalogVersionsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get catalog versions params
-func (o *GetCatalogVersionsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetCatalogVersionsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get catalog versions params
-func (o *GetCatalogVersionsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get catalog versions params
-func (o *GetCatalogVersionsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetCatalogVersionsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get catalog versions params
-func (o *GetCatalogVersionsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get catalog versions params
 func (o *GetCatalogVersionsParams) WithAccountID(accountID *strfmt.UUID) *GetCatalogVersionsParams {
 	o.SetAccountID(accountID)
@@ -149,16 +123,6 @@ func (o *GetCatalogVersionsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountID != nil {
 

--- a/kbclient/catalog/get_catalog_xml_parameters.go
+++ b/kbclient/catalog/get_catalog_xml_parameters.go
@@ -62,10 +62,6 @@ for the get catalog Xml operation typically these are written to a http.Request
 */
 type GetCatalogXMLParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID *strfmt.UUID
 	/*RequestedDate*/
@@ -111,28 +107,6 @@ func (o *GetCatalogXMLParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get catalog Xml params
-func (o *GetCatalogXMLParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetCatalogXMLParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get catalog Xml params
-func (o *GetCatalogXMLParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get catalog Xml params
-func (o *GetCatalogXMLParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetCatalogXMLParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get catalog Xml params
-func (o *GetCatalogXMLParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAccountID adds the accountID to the get catalog Xml params
 func (o *GetCatalogXMLParams) WithAccountID(accountID *strfmt.UUID) *GetCatalogXMLParams {
 	o.SetAccountID(accountID)
@@ -162,16 +136,6 @@ func (o *GetCatalogXMLParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.AccountID != nil {
 

--- a/kbclient/catalog/get_phase_for_subscription_and_date_parameters.go
+++ b/kbclient/catalog/get_phase_for_subscription_and_date_parameters.go
@@ -62,10 +62,6 @@ for the get phase for subscription and date operation typically these are writte
 */
 type GetPhaseForSubscriptionAndDateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*RequestedDate*/
 	RequestedDate *strfmt.Date
 	/*SubscriptionID*/
@@ -111,28 +107,6 @@ func (o *GetPhaseForSubscriptionAndDateParams) SetHTTPClient(client *http.Client
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get phase for subscription and date params
-func (o *GetPhaseForSubscriptionAndDateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPhaseForSubscriptionAndDateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get phase for subscription and date params
-func (o *GetPhaseForSubscriptionAndDateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get phase for subscription and date params
-func (o *GetPhaseForSubscriptionAndDateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPhaseForSubscriptionAndDateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get phase for subscription and date params
-func (o *GetPhaseForSubscriptionAndDateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithRequestedDate adds the requestedDate to the get phase for subscription and date params
 func (o *GetPhaseForSubscriptionAndDateParams) WithRequestedDate(requestedDate *strfmt.Date) *GetPhaseForSubscriptionAndDateParams {
 	o.SetRequestedDate(requestedDate)
@@ -162,16 +136,6 @@ func (o *GetPhaseForSubscriptionAndDateParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.RequestedDate != nil {
 

--- a/kbclient/catalog/get_plan_for_subscription_and_date_parameters.go
+++ b/kbclient/catalog/get_plan_for_subscription_and_date_parameters.go
@@ -62,10 +62,6 @@ for the get plan for subscription and date operation typically these are written
 */
 type GetPlanForSubscriptionAndDateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*RequestedDate*/
 	RequestedDate *strfmt.Date
 	/*SubscriptionID*/
@@ -111,28 +107,6 @@ func (o *GetPlanForSubscriptionAndDateParams) SetHTTPClient(client *http.Client)
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get plan for subscription and date params
-func (o *GetPlanForSubscriptionAndDateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPlanForSubscriptionAndDateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get plan for subscription and date params
-func (o *GetPlanForSubscriptionAndDateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get plan for subscription and date params
-func (o *GetPlanForSubscriptionAndDateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPlanForSubscriptionAndDateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get plan for subscription and date params
-func (o *GetPlanForSubscriptionAndDateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithRequestedDate adds the requestedDate to the get plan for subscription and date params
 func (o *GetPlanForSubscriptionAndDateParams) WithRequestedDate(requestedDate *strfmt.Date) *GetPlanForSubscriptionAndDateParams {
 	o.SetRequestedDate(requestedDate)
@@ -162,16 +136,6 @@ func (o *GetPlanForSubscriptionAndDateParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.RequestedDate != nil {
 

--- a/kbclient/catalog/get_price_list_for_subscription_and_date_parameters.go
+++ b/kbclient/catalog/get_price_list_for_subscription_and_date_parameters.go
@@ -62,10 +62,6 @@ for the get price list for subscription and date operation typically these are w
 */
 type GetPriceListForSubscriptionAndDateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*RequestedDate*/
 	RequestedDate *strfmt.Date
 	/*SubscriptionID*/
@@ -111,28 +107,6 @@ func (o *GetPriceListForSubscriptionAndDateParams) SetHTTPClient(client *http.Cl
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get price list for subscription and date params
-func (o *GetPriceListForSubscriptionAndDateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPriceListForSubscriptionAndDateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get price list for subscription and date params
-func (o *GetPriceListForSubscriptionAndDateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get price list for subscription and date params
-func (o *GetPriceListForSubscriptionAndDateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPriceListForSubscriptionAndDateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get price list for subscription and date params
-func (o *GetPriceListForSubscriptionAndDateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithRequestedDate adds the requestedDate to the get price list for subscription and date params
 func (o *GetPriceListForSubscriptionAndDateParams) WithRequestedDate(requestedDate *strfmt.Date) *GetPriceListForSubscriptionAndDateParams {
 	o.SetRequestedDate(requestedDate)
@@ -162,16 +136,6 @@ func (o *GetPriceListForSubscriptionAndDateParams) WriteToRequest(r runtime.Clie
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.RequestedDate != nil {
 

--- a/kbclient/catalog/get_product_for_subscription_and_date_parameters.go
+++ b/kbclient/catalog/get_product_for_subscription_and_date_parameters.go
@@ -62,10 +62,6 @@ for the get product for subscription and date operation typically these are writ
 */
 type GetProductForSubscriptionAndDateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*RequestedDate*/
 	RequestedDate *strfmt.Date
 	/*SubscriptionID*/
@@ -111,28 +107,6 @@ func (o *GetProductForSubscriptionAndDateParams) SetHTTPClient(client *http.Clie
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get product for subscription and date params
-func (o *GetProductForSubscriptionAndDateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetProductForSubscriptionAndDateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get product for subscription and date params
-func (o *GetProductForSubscriptionAndDateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get product for subscription and date params
-func (o *GetProductForSubscriptionAndDateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetProductForSubscriptionAndDateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get product for subscription and date params
-func (o *GetProductForSubscriptionAndDateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithRequestedDate adds the requestedDate to the get product for subscription and date params
 func (o *GetProductForSubscriptionAndDateParams) WithRequestedDate(requestedDate *strfmt.Date) *GetProductForSubscriptionAndDateParams {
 	o.SetRequestedDate(requestedDate)
@@ -162,16 +136,6 @@ func (o *GetProductForSubscriptionAndDateParams) WriteToRequest(r runtime.Client
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.RequestedDate != nil {
 

--- a/kbclient/catalog/upload_catalog_xml_parameters.go
+++ b/kbclient/catalog/upload_catalog_xml_parameters.go
@@ -62,10 +62,6 @@ for the upload catalog Xml operation typically these are written to a http.Reque
 */
 type UploadCatalogXMLParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *UploadCatalogXMLParams) WithHTTPClient(client *http.Client) *UploadCata
 // SetHTTPClient adds the HTTPClient to the upload catalog Xml params
 func (o *UploadCatalogXMLParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload catalog Xml params
-func (o *UploadCatalogXMLParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadCatalogXMLParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload catalog Xml params
-func (o *UploadCatalogXMLParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload catalog Xml params
-func (o *UploadCatalogXMLParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadCatalogXMLParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload catalog Xml params
-func (o *UploadCatalogXMLParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload catalog Xml params
@@ -188,16 +162,6 @@ func (o *UploadCatalogXMLParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/credit/create_credit_parameters.go
+++ b/kbclient/credit/create_credit_parameters.go
@@ -77,10 +77,6 @@ for the create credit operation typically these are written to a http.Request
 */
 type CreateCreditParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -132,28 +128,6 @@ func (o *CreateCreditParams) WithHTTPClient(client *http.Client) *CreateCreditPa
 // SetHTTPClient adds the HTTPClient to the create credit params
 func (o *CreateCreditParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create credit params
-func (o *CreateCreditParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateCreditParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create credit params
-func (o *CreateCreditParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create credit params
-func (o *CreateCreditParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateCreditParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create credit params
-func (o *CreateCreditParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create credit params
@@ -229,16 +203,6 @@ func (o *CreateCreditParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/credit/credit_client.go
+++ b/kbclient/credit/credit_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -74,31 +70,18 @@ func (a *Client) CreateCredit(ctx context.Context, params *CreateCreditParams) (
 	getParams := NewCreateCreditParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -155,14 +138,6 @@ func (a *Client) GetCredit(ctx context.Context, params *GetCreditParams) (*GetCr
 		params = NewGetCreditParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/credit/get_credit_parameters.go
+++ b/kbclient/credit/get_credit_parameters.go
@@ -62,10 +62,6 @@ for the get credit operation typically these are written to a http.Request
 */
 type GetCreditParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*CreditID*/
 	CreditID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetCreditParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get credit params
-func (o *GetCreditParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetCreditParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get credit params
-func (o *GetCreditParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get credit params
-func (o *GetCreditParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetCreditParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get credit params
-func (o *GetCreditParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithCreditID adds the creditID to the get credit params
 func (o *GetCreditParams) WithCreditID(creditID strfmt.UUID) *GetCreditParams {
 	o.SetCreditID(creditID)
@@ -149,16 +123,6 @@ func (o *GetCreditParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param creditId
 	if err := r.SetPathParam("creditId", o.CreditID.String()); err != nil {

--- a/kbclient/custom_field/custom_field_client.go
+++ b/kbclient/custom_field/custom_field_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -76,14 +72,6 @@ func (a *Client) GetCustomFieldAuditLogsWithHistory(ctx context.Context, params 
 		params = NewGetCustomFieldAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -117,14 +105,6 @@ func (a *Client) GetCustomFields(ctx context.Context, params *GetCustomFieldsPar
 		params = NewGetCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -158,14 +138,6 @@ func (a *Client) SearchCustomFields(ctx context.Context, params *SearchCustomFie
 		params = NewSearchCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/custom_field/get_custom_field_audit_logs_with_history_parameters.go
+++ b/kbclient/custom_field/get_custom_field_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get custom field audit logs with history operation typically these are w
 */
 type GetCustomFieldAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*CustomFieldID*/
 	CustomFieldID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetCustomFieldAuditLogsWithHistoryParams) SetHTTPClient(client *http.Cl
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get custom field audit logs with history params
-func (o *GetCustomFieldAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetCustomFieldAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get custom field audit logs with history params
-func (o *GetCustomFieldAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get custom field audit logs with history params
-func (o *GetCustomFieldAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetCustomFieldAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get custom field audit logs with history params
-func (o *GetCustomFieldAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithCustomFieldID adds the customFieldID to the get custom field audit logs with history params
 func (o *GetCustomFieldAuditLogsWithHistoryParams) WithCustomFieldID(customFieldID strfmt.UUID) *GetCustomFieldAuditLogsWithHistoryParams {
 	o.SetCustomFieldID(customFieldID)
@@ -149,16 +123,6 @@ func (o *GetCustomFieldAuditLogsWithHistoryParams) WriteToRequest(r runtime.Clie
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param customFieldId
 	if err := r.SetPathParam("customFieldId", o.CustomFieldID.String()); err != nil {

--- a/kbclient/custom_field/get_custom_fields_parameters.go
+++ b/kbclient/custom_field/get_custom_fields_parameters.go
@@ -91,10 +91,6 @@ for the get custom fields operation typically these are written to a http.Reques
 */
 type GetCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -142,28 +138,6 @@ func (o *GetCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get custom fields params
-func (o *GetCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get custom fields params
-func (o *GetCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get custom fields params
-func (o *GetCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get custom fields params
-func (o *GetCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get custom fields params
 func (o *GetCustomFieldsParams) WithAudit(audit *string) *GetCustomFieldsParams {
 	o.SetAudit(audit)
@@ -204,16 +178,6 @@ func (o *GetCustomFieldsParams) WriteToRequest(r runtime.ClientRequest, reg strf
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/custom_field/search_custom_fields_parameters.go
+++ b/kbclient/custom_field/search_custom_fields_parameters.go
@@ -91,10 +91,6 @@ for the search custom fields operation typically these are written to a http.Req
 */
 type SearchCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -142,28 +138,6 @@ func (o *SearchCustomFieldsParams) WithHTTPClient(client *http.Client) *SearchCu
 // SetHTTPClient adds the HTTPClient to the search custom fields params
 func (o *SearchCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the search custom fields params
-func (o *SearchCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SearchCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the search custom fields params
-func (o *SearchCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the search custom fields params
-func (o *SearchCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SearchCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the search custom fields params
-func (o *SearchCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the search custom fields params
@@ -217,16 +191,6 @@ func (o *SearchCustomFieldsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/debug/debug_client.go
+++ b/kbclient/debug/debug_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -71,14 +67,6 @@ func (a *Client) GetClock(ctx context.Context, params *GetClockParams) (*GetCloc
 		params = NewGetClockParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -112,14 +100,6 @@ func (a *Client) SetClock(ctx context.Context, params *SetClockParams) (*SetCloc
 		params = NewSetClockParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/export/export_client.go
+++ b/kbclient/export/export_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -66,14 +62,6 @@ func (a *Client) ExportDataForAccount(ctx context.Context, params *ExportDataFor
 		params = NewExportDataForAccountParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/export/export_data_for_account_parameters.go
+++ b/kbclient/export/export_data_for_account_parameters.go
@@ -62,10 +62,6 @@ for the export data for account operation typically these are written to a http.
 */
 type ExportDataForAccountParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *ExportDataForAccountParams) WithHTTPClient(client *http.Client) *Export
 // SetHTTPClient adds the HTTPClient to the export data for account params
 func (o *ExportDataForAccountParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the export data for account params
-func (o *ExportDataForAccountParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ExportDataForAccountParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the export data for account params
-func (o *ExportDataForAccountParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the export data for account params
-func (o *ExportDataForAccountParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ExportDataForAccountParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the export data for account params
-func (o *ExportDataForAccountParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the export data for account params
@@ -188,16 +162,6 @@ func (o *ExportDataForAccountParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/adjust_invoice_item_parameters.go
+++ b/kbclient/invoice/adjust_invoice_item_parameters.go
@@ -65,10 +65,6 @@ for the adjust invoice item operation typically these are written to a http.Requ
 */
 type AdjustInvoiceItemParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *AdjustInvoiceItemParams) WithHTTPClient(client *http.Client) *AdjustInv
 // SetHTTPClient adds the HTTPClient to the adjust invoice item params
 func (o *AdjustInvoiceItemParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the adjust invoice item params
-func (o *AdjustInvoiceItemParams) WithXKillbillAPIKey(xKillbillAPIKey string) *AdjustInvoiceItemParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the adjust invoice item params
-func (o *AdjustInvoiceItemParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the adjust invoice item params
-func (o *AdjustInvoiceItemParams) WithXKillbillAPISecret(xKillbillAPISecret string) *AdjustInvoiceItemParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the adjust invoice item params
-func (o *AdjustInvoiceItemParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the adjust invoice item params
@@ -230,16 +204,6 @@ func (o *AdjustInvoiceItemParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/commit_invoice_parameters.go
+++ b/kbclient/invoice/commit_invoice_parameters.go
@@ -62,10 +62,6 @@ for the commit invoice operation typically these are written to a http.Request
 */
 type CommitInvoiceParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *CommitInvoiceParams) WithHTTPClient(client *http.Client) *CommitInvoice
 // SetHTTPClient adds the HTTPClient to the commit invoice params
 func (o *CommitInvoiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the commit invoice params
-func (o *CommitInvoiceParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CommitInvoiceParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the commit invoice params
-func (o *CommitInvoiceParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the commit invoice params
-func (o *CommitInvoiceParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CommitInvoiceParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the commit invoice params
-func (o *CommitInvoiceParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the commit invoice params
@@ -188,16 +162,6 @@ func (o *CommitInvoiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/create_external_charges_parameters.go
+++ b/kbclient/invoice/create_external_charges_parameters.go
@@ -77,10 +77,6 @@ for the create external charges operation typically these are written to a http.
 */
 type CreateExternalChargesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -136,28 +132,6 @@ func (o *CreateExternalChargesParams) WithHTTPClient(client *http.Client) *Creat
 // SetHTTPClient adds the HTTPClient to the create external charges params
 func (o *CreateExternalChargesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create external charges params
-func (o *CreateExternalChargesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateExternalChargesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create external charges params
-func (o *CreateExternalChargesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create external charges params
-func (o *CreateExternalChargesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateExternalChargesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create external charges params
-func (o *CreateExternalChargesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create external charges params
@@ -255,16 +229,6 @@ func (o *CreateExternalChargesParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/create_future_invoice_parameters.go
+++ b/kbclient/invoice/create_future_invoice_parameters.go
@@ -62,10 +62,6 @@ for the create future invoice operation typically these are written to a http.Re
 */
 type CreateFutureInvoiceParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateFutureInvoiceParams) WithHTTPClient(client *http.Client) *CreateF
 // SetHTTPClient adds the HTTPClient to the create future invoice params
 func (o *CreateFutureInvoiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create future invoice params
-func (o *CreateFutureInvoiceParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateFutureInvoiceParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create future invoice params
-func (o *CreateFutureInvoiceParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create future invoice params
-func (o *CreateFutureInvoiceParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateFutureInvoiceParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create future invoice params
-func (o *CreateFutureInvoiceParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create future invoice params
@@ -201,16 +175,6 @@ func (o *CreateFutureInvoiceParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/create_instant_payment_parameters.go
+++ b/kbclient/invoice/create_instant_payment_parameters.go
@@ -77,10 +77,6 @@ for the create instant payment operation typically these are written to a http.R
 */
 type CreateInstantPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -134,28 +130,6 @@ func (o *CreateInstantPaymentParams) WithHTTPClient(client *http.Client) *Create
 // SetHTTPClient adds the HTTPClient to the create instant payment params
 func (o *CreateInstantPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create instant payment params
-func (o *CreateInstantPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateInstantPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create instant payment params
-func (o *CreateInstantPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create instant payment params
-func (o *CreateInstantPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateInstantPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create instant payment params
-func (o *CreateInstantPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create instant payment params
@@ -242,16 +216,6 @@ func (o *CreateInstantPaymentParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/create_invoice_custom_fields_parameters.go
+++ b/kbclient/invoice/create_invoice_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create invoice custom fields operation typically these are written to a 
 */
 type CreateInvoiceCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreateInvoiceCustomFieldsParams) WithHTTPClient(client *http.Client) *C
 // SetHTTPClient adds the HTTPClient to the create invoice custom fields params
 func (o *CreateInvoiceCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create invoice custom fields params
-func (o *CreateInvoiceCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateInvoiceCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create invoice custom fields params
-func (o *CreateInvoiceCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create invoice custom fields params
-func (o *CreateInvoiceCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateInvoiceCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create invoice custom fields params
-func (o *CreateInvoiceCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create invoice custom fields params
@@ -203,16 +177,6 @@ func (o *CreateInvoiceCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/create_invoice_tags_parameters.go
+++ b/kbclient/invoice/create_invoice_tags_parameters.go
@@ -62,10 +62,6 @@ for the create invoice tags operation typically these are written to a http.Requ
 */
 type CreateInvoiceTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateInvoiceTagsParams) WithHTTPClient(client *http.Client) *CreateInv
 // SetHTTPClient adds the HTTPClient to the create invoice tags params
 func (o *CreateInvoiceTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create invoice tags params
-func (o *CreateInvoiceTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateInvoiceTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create invoice tags params
-func (o *CreateInvoiceTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create invoice tags params
-func (o *CreateInvoiceTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateInvoiceTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create invoice tags params
-func (o *CreateInvoiceTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create invoice tags params
@@ -201,16 +175,6 @@ func (o *CreateInvoiceTagsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/create_migration_invoice_parameters.go
+++ b/kbclient/invoice/create_migration_invoice_parameters.go
@@ -64,10 +64,6 @@ for the create migration invoice operation typically these are written to a http
 */
 type CreateMigrationInvoiceParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -119,28 +115,6 @@ func (o *CreateMigrationInvoiceParams) WithHTTPClient(client *http.Client) *Crea
 // SetHTTPClient adds the HTTPClient to the create migration invoice params
 func (o *CreateMigrationInvoiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create migration invoice params
-func (o *CreateMigrationInvoiceParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateMigrationInvoiceParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create migration invoice params
-func (o *CreateMigrationInvoiceParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create migration invoice params
-func (o *CreateMigrationInvoiceParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateMigrationInvoiceParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create migration invoice params
-func (o *CreateMigrationInvoiceParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create migration invoice params
@@ -216,16 +190,6 @@ func (o *CreateMigrationInvoiceParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/create_tax_items_parameters.go
+++ b/kbclient/invoice/create_tax_items_parameters.go
@@ -77,10 +77,6 @@ for the create tax items operation typically these are written to a http.Request
 */
 type CreateTaxItemsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -136,28 +132,6 @@ func (o *CreateTaxItemsParams) WithHTTPClient(client *http.Client) *CreateTaxIte
 // SetHTTPClient adds the HTTPClient to the create tax items params
 func (o *CreateTaxItemsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create tax items params
-func (o *CreateTaxItemsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateTaxItemsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create tax items params
-func (o *CreateTaxItemsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create tax items params
-func (o *CreateTaxItemsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateTaxItemsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create tax items params
-func (o *CreateTaxItemsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create tax items params
@@ -255,16 +229,6 @@ func (o *CreateTaxItemsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/delete_c_b_a_parameters.go
+++ b/kbclient/invoice/delete_c_b_a_parameters.go
@@ -62,10 +62,6 @@ for the delete c b a operation typically these are written to a http.Request
 */
 type DeleteCBAParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *DeleteCBAParams) WithHTTPClient(client *http.Client) *DeleteCBAParams {
 // SetHTTPClient adds the HTTPClient to the delete c b a params
 func (o *DeleteCBAParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete c b a params
-func (o *DeleteCBAParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteCBAParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete c b a params
-func (o *DeleteCBAParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete c b a params
-func (o *DeleteCBAParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteCBAParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete c b a params
-func (o *DeleteCBAParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete c b a params
@@ -214,16 +188,6 @@ func (o *DeleteCBAParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/delete_invoice_custom_fields_parameters.go
+++ b/kbclient/invoice/delete_invoice_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete invoice custom fields operation typically these are written to a 
 */
 type DeleteInvoiceCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteInvoiceCustomFieldsParams) WithHTTPClient(client *http.Client) *D
 // SetHTTPClient adds the HTTPClient to the delete invoice custom fields params
 func (o *DeleteInvoiceCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete invoice custom fields params
-func (o *DeleteInvoiceCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteInvoiceCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete invoice custom fields params
-func (o *DeleteInvoiceCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete invoice custom fields params
-func (o *DeleteInvoiceCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteInvoiceCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete invoice custom fields params
-func (o *DeleteInvoiceCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete invoice custom fields params
@@ -202,16 +176,6 @@ func (o *DeleteInvoiceCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/delete_invoice_tags_parameters.go
+++ b/kbclient/invoice/delete_invoice_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete invoice tags operation typically these are written to a http.Requ
 */
 type DeleteInvoiceTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteInvoiceTagsParams) WithHTTPClient(client *http.Client) *DeleteInv
 // SetHTTPClient adds the HTTPClient to the delete invoice tags params
 func (o *DeleteInvoiceTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete invoice tags params
-func (o *DeleteInvoiceTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteInvoiceTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete invoice tags params
-func (o *DeleteInvoiceTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete invoice tags params
-func (o *DeleteInvoiceTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteInvoiceTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete invoice tags params
-func (o *DeleteInvoiceTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete invoice tags params
@@ -202,16 +176,6 @@ func (o *DeleteInvoiceTagsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/generate_dry_run_invoice_parameters.go
+++ b/kbclient/invoice/generate_dry_run_invoice_parameters.go
@@ -64,10 +64,6 @@ for the generate dry run invoice operation typically these are written to a http
 */
 type GenerateDryRunInvoiceParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -119,28 +115,6 @@ func (o *GenerateDryRunInvoiceParams) WithHTTPClient(client *http.Client) *Gener
 // SetHTTPClient adds the HTTPClient to the generate dry run invoice params
 func (o *GenerateDryRunInvoiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the generate dry run invoice params
-func (o *GenerateDryRunInvoiceParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GenerateDryRunInvoiceParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the generate dry run invoice params
-func (o *GenerateDryRunInvoiceParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the generate dry run invoice params
-func (o *GenerateDryRunInvoiceParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GenerateDryRunInvoiceParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the generate dry run invoice params
-func (o *GenerateDryRunInvoiceParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the generate dry run invoice params
@@ -216,16 +190,6 @@ func (o *GenerateDryRunInvoiceParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/get_catalog_translation_parameters.go
+++ b/kbclient/invoice/get_catalog_translation_parameters.go
@@ -62,10 +62,6 @@ for the get catalog translation operation typically these are written to a http.
 */
 type GetCatalogTranslationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Locale*/
 	Locale string
 
@@ -109,28 +105,6 @@ func (o *GetCatalogTranslationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get catalog translation params
-func (o *GetCatalogTranslationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetCatalogTranslationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get catalog translation params
-func (o *GetCatalogTranslationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get catalog translation params
-func (o *GetCatalogTranslationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetCatalogTranslationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get catalog translation params
-func (o *GetCatalogTranslationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithLocale adds the locale to the get catalog translation params
 func (o *GetCatalogTranslationParams) WithLocale(locale string) *GetCatalogTranslationParams {
 	o.SetLocale(locale)
@@ -149,16 +123,6 @@ func (o *GetCatalogTranslationParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param locale
 	if err := r.SetPathParam("locale", o.Locale); err != nil {

--- a/kbclient/invoice/get_invoice_as_html_parameters.go
+++ b/kbclient/invoice/get_invoice_as_html_parameters.go
@@ -62,10 +62,6 @@ for the get invoice as HTML operation typically these are written to a http.Requ
 */
 type GetInvoiceAsHTMLParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*InvoiceID*/
 	InvoiceID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetInvoiceAsHTMLParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice as HTML params
-func (o *GetInvoiceAsHTMLParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceAsHTMLParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice as HTML params
-func (o *GetInvoiceAsHTMLParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice as HTML params
-func (o *GetInvoiceAsHTMLParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceAsHTMLParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice as HTML params
-func (o *GetInvoiceAsHTMLParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithInvoiceID adds the invoiceID to the get invoice as HTML params
 func (o *GetInvoiceAsHTMLParams) WithInvoiceID(invoiceID strfmt.UUID) *GetInvoiceAsHTMLParams {
 	o.SetInvoiceID(invoiceID)
@@ -149,16 +123,6 @@ func (o *GetInvoiceAsHTMLParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param invoiceId
 	if err := r.SetPathParam("invoiceId", o.InvoiceID.String()); err != nil {

--- a/kbclient/invoice/get_invoice_by_item_id_parameters.go
+++ b/kbclient/invoice/get_invoice_by_item_id_parameters.go
@@ -91,10 +91,6 @@ for the get invoice by item Id operation typically these are written to a http.R
 */
 type GetInvoiceByItemIDParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*ItemID*/
@@ -142,28 +138,6 @@ func (o *GetInvoiceByItemIDParams) WithHTTPClient(client *http.Client) *GetInvoi
 // SetHTTPClient adds the HTTPClient to the get invoice by item Id params
 func (o *GetInvoiceByItemIDParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice by item Id params
-func (o *GetInvoiceByItemIDParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceByItemIDParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice by item Id params
-func (o *GetInvoiceByItemIDParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice by item Id params
-func (o *GetInvoiceByItemIDParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceByItemIDParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice by item Id params
-func (o *GetInvoiceByItemIDParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get invoice by item Id params
@@ -217,16 +191,6 @@ func (o *GetInvoiceByItemIDParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/get_invoice_by_number_parameters.go
+++ b/kbclient/invoice/get_invoice_by_number_parameters.go
@@ -91,10 +91,6 @@ for the get invoice by number operation typically these are written to a http.Re
 */
 type GetInvoiceByNumberParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*InvoiceNumber*/
@@ -142,28 +138,6 @@ func (o *GetInvoiceByNumberParams) WithHTTPClient(client *http.Client) *GetInvoi
 // SetHTTPClient adds the HTTPClient to the get invoice by number params
 func (o *GetInvoiceByNumberParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice by number params
-func (o *GetInvoiceByNumberParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceByNumberParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice by number params
-func (o *GetInvoiceByNumberParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice by number params
-func (o *GetInvoiceByNumberParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceByNumberParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice by number params
-func (o *GetInvoiceByNumberParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get invoice by number params
@@ -217,16 +191,6 @@ func (o *GetInvoiceByNumberParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/get_invoice_custom_fields_parameters.go
+++ b/kbclient/invoice/get_invoice_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get invoice custom fields operation typically these are written to a htt
 */
 type GetInvoiceCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*InvoiceID*/
@@ -123,28 +119,6 @@ func (o *GetInvoiceCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice custom fields params
-func (o *GetInvoiceCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice custom fields params
-func (o *GetInvoiceCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice custom fields params
-func (o *GetInvoiceCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice custom fields params
-func (o *GetInvoiceCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get invoice custom fields params
 func (o *GetInvoiceCustomFieldsParams) WithAudit(audit *string) *GetInvoiceCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetInvoiceCustomFieldsParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/get_invoice_m_p_template_parameters.go
+++ b/kbclient/invoice/get_invoice_m_p_template_parameters.go
@@ -62,10 +62,6 @@ for the get invoice m p template operation typically these are written to a http
 */
 type GetInvoiceMPTemplateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Locale*/
 	Locale string
 
@@ -109,28 +105,6 @@ func (o *GetInvoiceMPTemplateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice m p template params
-func (o *GetInvoiceMPTemplateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceMPTemplateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice m p template params
-func (o *GetInvoiceMPTemplateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice m p template params
-func (o *GetInvoiceMPTemplateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceMPTemplateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice m p template params
-func (o *GetInvoiceMPTemplateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithLocale adds the locale to the get invoice m p template params
 func (o *GetInvoiceMPTemplateParams) WithLocale(locale string) *GetInvoiceMPTemplateParams {
 	o.SetLocale(locale)
@@ -149,16 +123,6 @@ func (o *GetInvoiceMPTemplateParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param locale
 	if err := r.SetPathParam("locale", o.Locale); err != nil {

--- a/kbclient/invoice/get_invoice_parameters.go
+++ b/kbclient/invoice/get_invoice_parameters.go
@@ -91,10 +91,6 @@ for the get invoice operation typically these are written to a http.Request
 */
 type GetInvoiceParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*InvoiceID*/
@@ -142,28 +138,6 @@ func (o *GetInvoiceParams) WithHTTPClient(client *http.Client) *GetInvoiceParams
 // SetHTTPClient adds the HTTPClient to the get invoice params
 func (o *GetInvoiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice params
-func (o *GetInvoiceParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice params
-func (o *GetInvoiceParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice params
-func (o *GetInvoiceParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice params
-func (o *GetInvoiceParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get invoice params
@@ -217,16 +191,6 @@ func (o *GetInvoiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/get_invoice_tags_parameters.go
+++ b/kbclient/invoice/get_invoice_tags_parameters.go
@@ -83,10 +83,6 @@ for the get invoice tags operation typically these are written to a http.Request
 */
 type GetInvoiceTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*IncludedDeleted*/
@@ -134,28 +130,6 @@ func (o *GetInvoiceTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice tags params
-func (o *GetInvoiceTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice tags params
-func (o *GetInvoiceTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice tags params
-func (o *GetInvoiceTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice tags params
-func (o *GetInvoiceTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get invoice tags params
 func (o *GetInvoiceTagsParams) WithAudit(audit *string) *GetInvoiceTagsParams {
 	o.SetAudit(audit)
@@ -196,16 +170,6 @@ func (o *GetInvoiceTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/get_invoice_template_parameters.go
+++ b/kbclient/invoice/get_invoice_template_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewGetInvoiceTemplateParams creates a new GetInvoiceTemplateParams object
 // with the default values initialized.
 func NewGetInvoiceTemplateParams() *GetInvoiceTemplateParams {
-	var ()
+
 	return &GetInvoiceTemplateParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewGetInvoiceTemplateParams() *GetInvoiceTemplateParams {
 // NewGetInvoiceTemplateParamsWithTimeout creates a new GetInvoiceTemplateParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetInvoiceTemplateParamsWithTimeout(timeout time.Duration) *GetInvoiceTemplateParams {
-	var ()
+
 	return &GetInvoiceTemplateParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewGetInvoiceTemplateParamsWithTimeout(timeout time.Duration) *GetInvoiceTe
 // NewGetInvoiceTemplateParamsWithContext creates a new GetInvoiceTemplateParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetInvoiceTemplateParamsWithContext(ctx context.Context) *GetInvoiceTemplateParams {
-	var ()
+
 	return &GetInvoiceTemplateParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewGetInvoiceTemplateParamsWithContext(ctx context.Context) *GetInvoiceTemp
 // NewGetInvoiceTemplateParamsWithHTTPClient creates a new GetInvoiceTemplateParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetInvoiceTemplateParamsWithHTTPClient(client *http.Client) *GetInvoiceTemplateParams {
-	var ()
+
 	return &GetInvoiceTemplateParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewGetInvoiceTemplateParamsWithHTTPClient(client *http.Client) *GetInvoiceT
 for the get invoice template operation typically these are written to a http.Request
 */
 type GetInvoiceTemplateParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *GetInvoiceTemplateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice template params
-func (o *GetInvoiceTemplateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceTemplateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice template params
-func (o *GetInvoiceTemplateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice template params
-func (o *GetInvoiceTemplateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceTemplateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice template params
-func (o *GetInvoiceTemplateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *GetInvoiceTemplateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *GetInvoiceTemplateParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/invoice/get_invoice_translation_parameters.go
+++ b/kbclient/invoice/get_invoice_translation_parameters.go
@@ -62,10 +62,6 @@ for the get invoice translation operation typically these are written to a http.
 */
 type GetInvoiceTranslationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Locale*/
 	Locale string
 
@@ -109,28 +105,6 @@ func (o *GetInvoiceTranslationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice translation params
-func (o *GetInvoiceTranslationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceTranslationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice translation params
-func (o *GetInvoiceTranslationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice translation params
-func (o *GetInvoiceTranslationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceTranslationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice translation params
-func (o *GetInvoiceTranslationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithLocale adds the locale to the get invoice translation params
 func (o *GetInvoiceTranslationParams) WithLocale(locale string) *GetInvoiceTranslationParams {
 	o.SetLocale(locale)
@@ -149,16 +123,6 @@ func (o *GetInvoiceTranslationParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param locale
 	if err := r.SetPathParam("locale", o.Locale); err != nil {

--- a/kbclient/invoice/get_invoices_parameters.go
+++ b/kbclient/invoice/get_invoices_parameters.go
@@ -99,10 +99,6 @@ for the get invoices operation typically these are written to a http.Request
 */
 type GetInvoicesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -150,28 +146,6 @@ func (o *GetInvoicesParams) WithHTTPClient(client *http.Client) *GetInvoicesPara
 // SetHTTPClient adds the HTTPClient to the get invoices params
 func (o *GetInvoicesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoices params
-func (o *GetInvoicesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoicesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoices params
-func (o *GetInvoicesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoices params
-func (o *GetInvoicesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoicesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoices params
-func (o *GetInvoicesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get invoices params
@@ -225,16 +199,6 @@ func (o *GetInvoicesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/get_payments_for_invoice_parameters.go
+++ b/kbclient/invoice/get_payments_for_invoice_parameters.go
@@ -91,10 +91,6 @@ for the get payments for invoice operation typically these are written to a http
 */
 type GetPaymentsForInvoiceParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*InvoiceID*/
@@ -142,28 +138,6 @@ func (o *GetPaymentsForInvoiceParams) WithHTTPClient(client *http.Client) *GetPa
 // SetHTTPClient adds the HTTPClient to the get payments for invoice params
 func (o *GetPaymentsForInvoiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payments for invoice params
-func (o *GetPaymentsForInvoiceParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentsForInvoiceParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payments for invoice params
-func (o *GetPaymentsForInvoiceParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payments for invoice params
-func (o *GetPaymentsForInvoiceParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentsForInvoiceParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payments for invoice params
-func (o *GetPaymentsForInvoiceParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payments for invoice params
@@ -217,16 +191,6 @@ func (o *GetPaymentsForInvoiceParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/invoice_client.go
+++ b/kbclient/invoice/invoice_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -224,31 +220,18 @@ func (a *Client) AdjustInvoiceItem(ctx context.Context, params *AdjustInvoiceIte
 	getParams := NewAdjustInvoiceItemParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -305,14 +288,6 @@ func (a *Client) CommitInvoice(ctx context.Context, params *CommitInvoiceParams)
 		params = NewCommitInvoiceParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -360,31 +335,18 @@ func (a *Client) CreateExternalCharges(ctx context.Context, params *CreateExtern
 	getParams := NewCreateExternalChargesParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -443,31 +405,18 @@ func (a *Client) CreateFutureInvoice(ctx context.Context, params *CreateFutureIn
 	getParams := NewCreateFutureInvoiceParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -524,14 +473,6 @@ func (a *Client) CreateInstantPayment(ctx context.Context, params *CreateInstant
 		params = NewCreateInstantPaymentParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -585,31 +526,18 @@ func (a *Client) CreateInvoiceCustomFields(ctx context.Context, params *CreateIn
 	getParams := NewCreateInvoiceCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -668,31 +596,18 @@ func (a *Client) CreateInvoiceTags(ctx context.Context, params *CreateInvoiceTag
 	getParams := NewCreateInvoiceTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -751,31 +666,18 @@ func (a *Client) CreateMigrationInvoice(ctx context.Context, params *CreateMigra
 	getParams := NewCreateMigrationInvoiceParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -834,31 +736,18 @@ func (a *Client) CreateTaxItems(ctx context.Context, params *CreateTaxItemsParam
 	getParams := NewCreateTaxItemsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -915,14 +804,6 @@ func (a *Client) DeleteCBA(ctx context.Context, params *DeleteCBAParams) (*Delet
 		params = NewDeleteCBAParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -968,14 +849,6 @@ func (a *Client) DeleteInvoiceCustomFields(ctx context.Context, params *DeleteIn
 		params = NewDeleteInvoiceCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1021,14 +894,6 @@ func (a *Client) DeleteInvoiceTags(ctx context.Context, params *DeleteInvoiceTag
 		params = NewDeleteInvoiceTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1074,14 +939,6 @@ func (a *Client) GenerateDryRunInvoice(ctx context.Context, params *GenerateDryR
 		params = NewGenerateDryRunInvoiceParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1133,14 +990,6 @@ func (a *Client) GetCatalogTranslation(ctx context.Context, params *GetCatalogTr
 		params = NewGetCatalogTranslationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1174,14 +1023,6 @@ func (a *Client) GetInvoice(ctx context.Context, params *GetInvoiceParams) (*Get
 		params = NewGetInvoiceParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1215,14 +1056,6 @@ func (a *Client) GetInvoiceAsHTML(ctx context.Context, params *GetInvoiceAsHTMLP
 		params = NewGetInvoiceAsHTMLParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1256,14 +1089,6 @@ func (a *Client) GetInvoiceByItemID(ctx context.Context, params *GetInvoiceByIte
 		params = NewGetInvoiceByItemIDParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1297,14 +1122,6 @@ func (a *Client) GetInvoiceByNumber(ctx context.Context, params *GetInvoiceByNum
 		params = NewGetInvoiceByNumberParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1338,14 +1155,6 @@ func (a *Client) GetInvoiceCustomFields(ctx context.Context, params *GetInvoiceC
 		params = NewGetInvoiceCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1379,14 +1188,6 @@ func (a *Client) GetInvoiceMPTemplate(ctx context.Context, params *GetInvoiceMPT
 		params = NewGetInvoiceMPTemplateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1420,14 +1221,6 @@ func (a *Client) GetInvoiceTags(ctx context.Context, params *GetInvoiceTagsParam
 		params = NewGetInvoiceTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1461,14 +1254,6 @@ func (a *Client) GetInvoiceTemplate(ctx context.Context, params *GetInvoiceTempl
 		params = NewGetInvoiceTemplateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1502,14 +1287,6 @@ func (a *Client) GetInvoiceTranslation(ctx context.Context, params *GetInvoiceTr
 		params = NewGetInvoiceTranslationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1543,14 +1320,6 @@ func (a *Client) GetInvoices(ctx context.Context, params *GetInvoicesParams) (*G
 		params = NewGetInvoicesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1584,14 +1353,6 @@ func (a *Client) GetPaymentsForInvoice(ctx context.Context, params *GetPaymentsF
 		params = NewGetPaymentsForInvoiceParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1625,14 +1386,6 @@ func (a *Client) ModifyInvoiceCustomFields(ctx context.Context, params *ModifyIn
 		params = NewModifyInvoiceCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1678,14 +1431,6 @@ func (a *Client) SearchInvoices(ctx context.Context, params *SearchInvoicesParam
 		params = NewSearchInvoicesParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1721,31 +1466,18 @@ func (a *Client) UploadCatalogTranslation(ctx context.Context, params *UploadCat
 	getParams := NewUploadCatalogTranslationParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1802,14 +1534,6 @@ func (a *Client) UploadInvoiceMPTemplate(ctx context.Context, params *UploadInvo
 		params = NewUploadInvoiceMPTemplateParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1857,31 +1581,18 @@ func (a *Client) UploadInvoiceTemplate(ctx context.Context, params *UploadInvoic
 	getParams := NewUploadInvoiceTemplateParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1940,31 +1651,18 @@ func (a *Client) UploadInvoiceTranslation(ctx context.Context, params *UploadInv
 	getParams := NewUploadInvoiceTranslationParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -2021,14 +1719,6 @@ func (a *Client) VoidInvoice(ctx context.Context, params *VoidInvoiceParams) (*V
 		params = NewVoidInvoiceParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/invoice/modify_invoice_custom_fields_parameters.go
+++ b/kbclient/invoice/modify_invoice_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify invoice custom fields operation typically these are written to a 
 */
 type ModifyInvoiceCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyInvoiceCustomFieldsParams) WithHTTPClient(client *http.Client) *M
 // SetHTTPClient adds the HTTPClient to the modify invoice custom fields params
 func (o *ModifyInvoiceCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify invoice custom fields params
-func (o *ModifyInvoiceCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyInvoiceCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify invoice custom fields params
-func (o *ModifyInvoiceCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify invoice custom fields params
-func (o *ModifyInvoiceCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyInvoiceCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify invoice custom fields params
-func (o *ModifyInvoiceCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify invoice custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyInvoiceCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/search_invoices_parameters.go
+++ b/kbclient/invoice/search_invoices_parameters.go
@@ -99,10 +99,6 @@ for the search invoices operation typically these are written to a http.Request
 */
 type SearchInvoicesParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -152,28 +148,6 @@ func (o *SearchInvoicesParams) WithHTTPClient(client *http.Client) *SearchInvoic
 // SetHTTPClient adds the HTTPClient to the search invoices params
 func (o *SearchInvoicesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the search invoices params
-func (o *SearchInvoicesParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SearchInvoicesParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the search invoices params
-func (o *SearchInvoicesParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the search invoices params
-func (o *SearchInvoicesParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SearchInvoicesParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the search invoices params
-func (o *SearchInvoicesParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the search invoices params
@@ -238,16 +212,6 @@ func (o *SearchInvoicesParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice/upload_catalog_translation_parameters.go
+++ b/kbclient/invoice/upload_catalog_translation_parameters.go
@@ -75,10 +75,6 @@ for the upload catalog translation operation typically these are written to a ht
 */
 type UploadCatalogTranslationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -130,28 +126,6 @@ func (o *UploadCatalogTranslationParams) WithHTTPClient(client *http.Client) *Up
 // SetHTTPClient adds the HTTPClient to the upload catalog translation params
 func (o *UploadCatalogTranslationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload catalog translation params
-func (o *UploadCatalogTranslationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadCatalogTranslationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload catalog translation params
-func (o *UploadCatalogTranslationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload catalog translation params
-func (o *UploadCatalogTranslationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadCatalogTranslationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload catalog translation params
-func (o *UploadCatalogTranslationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload catalog translation params
@@ -227,16 +201,6 @@ func (o *UploadCatalogTranslationParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/upload_invoice_m_p_template_parameters.go
+++ b/kbclient/invoice/upload_invoice_m_p_template_parameters.go
@@ -75,10 +75,6 @@ for the upload invoice m p template operation typically these are written to a h
 */
 type UploadInvoiceMPTemplateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -128,28 +124,6 @@ func (o *UploadInvoiceMPTemplateParams) WithHTTPClient(client *http.Client) *Upl
 // SetHTTPClient adds the HTTPClient to the upload invoice m p template params
 func (o *UploadInvoiceMPTemplateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload invoice m p template params
-func (o *UploadInvoiceMPTemplateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadInvoiceMPTemplateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload invoice m p template params
-func (o *UploadInvoiceMPTemplateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload invoice m p template params
-func (o *UploadInvoiceMPTemplateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadInvoiceMPTemplateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload invoice m p template params
-func (o *UploadInvoiceMPTemplateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload invoice m p template params
@@ -214,16 +188,6 @@ func (o *UploadInvoiceMPTemplateParams) WriteToRequest(r runtime.ClientRequest, 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/upload_invoice_template_parameters.go
+++ b/kbclient/invoice/upload_invoice_template_parameters.go
@@ -75,10 +75,6 @@ for the upload invoice template operation typically these are written to a http.
 */
 type UploadInvoiceTemplateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -128,28 +124,6 @@ func (o *UploadInvoiceTemplateParams) WithHTTPClient(client *http.Client) *Uploa
 // SetHTTPClient adds the HTTPClient to the upload invoice template params
 func (o *UploadInvoiceTemplateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload invoice template params
-func (o *UploadInvoiceTemplateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadInvoiceTemplateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload invoice template params
-func (o *UploadInvoiceTemplateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload invoice template params
-func (o *UploadInvoiceTemplateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadInvoiceTemplateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload invoice template params
-func (o *UploadInvoiceTemplateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload invoice template params
@@ -214,16 +188,6 @@ func (o *UploadInvoiceTemplateParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/upload_invoice_translation_parameters.go
+++ b/kbclient/invoice/upload_invoice_translation_parameters.go
@@ -75,10 +75,6 @@ for the upload invoice translation operation typically these are written to a ht
 */
 type UploadInvoiceTranslationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -130,28 +126,6 @@ func (o *UploadInvoiceTranslationParams) WithHTTPClient(client *http.Client) *Up
 // SetHTTPClient adds the HTTPClient to the upload invoice translation params
 func (o *UploadInvoiceTranslationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload invoice translation params
-func (o *UploadInvoiceTranslationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadInvoiceTranslationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload invoice translation params
-func (o *UploadInvoiceTranslationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload invoice translation params
-func (o *UploadInvoiceTranslationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadInvoiceTranslationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload invoice translation params
-func (o *UploadInvoiceTranslationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload invoice translation params
@@ -227,16 +201,6 @@ func (o *UploadInvoiceTranslationParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice/void_invoice_parameters.go
+++ b/kbclient/invoice/void_invoice_parameters.go
@@ -62,10 +62,6 @@ for the void invoice operation typically these are written to a http.Request
 */
 type VoidInvoiceParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *VoidInvoiceParams) WithHTTPClient(client *http.Client) *VoidInvoicePara
 // SetHTTPClient adds the HTTPClient to the void invoice params
 func (o *VoidInvoiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the void invoice params
-func (o *VoidInvoiceParams) WithXKillbillAPIKey(xKillbillAPIKey string) *VoidInvoiceParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the void invoice params
-func (o *VoidInvoiceParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the void invoice params
-func (o *VoidInvoiceParams) WithXKillbillAPISecret(xKillbillAPISecret string) *VoidInvoiceParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the void invoice params
-func (o *VoidInvoiceParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the void invoice params
@@ -188,16 +162,6 @@ func (o *VoidInvoiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_item/create_invoice_item_custom_fields_parameters.go
+++ b/kbclient/invoice_item/create_invoice_item_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create invoice item custom fields operation typically these are written 
 */
 type CreateInvoiceItemCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreateInvoiceItemCustomFieldsParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the create invoice item custom fields params
 func (o *CreateInvoiceItemCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create invoice item custom fields params
-func (o *CreateInvoiceItemCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create invoice item custom fields params
-func (o *CreateInvoiceItemCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create invoice item custom fields params
-func (o *CreateInvoiceItemCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create invoice item custom fields params
-func (o *CreateInvoiceItemCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create invoice item custom fields params
@@ -203,16 +177,6 @@ func (o *CreateInvoiceItemCustomFieldsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_item/create_invoice_item_tags_parameters.go
+++ b/kbclient/invoice_item/create_invoice_item_tags_parameters.go
@@ -62,10 +62,6 @@ for the create invoice item tags operation typically these are written to a http
 */
 type CreateInvoiceItemTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateInvoiceItemTagsParams) WithHTTPClient(client *http.Client) *Creat
 // SetHTTPClient adds the HTTPClient to the create invoice item tags params
 func (o *CreateInvoiceItemTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create invoice item tags params
-func (o *CreateInvoiceItemTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateInvoiceItemTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create invoice item tags params
-func (o *CreateInvoiceItemTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create invoice item tags params
-func (o *CreateInvoiceItemTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateInvoiceItemTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create invoice item tags params
-func (o *CreateInvoiceItemTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create invoice item tags params
@@ -201,16 +175,6 @@ func (o *CreateInvoiceItemTagsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_item/delete_invoice_item_custom_fields_parameters.go
+++ b/kbclient/invoice_item/delete_invoice_item_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete invoice item custom fields operation typically these are written 
 */
 type DeleteInvoiceItemCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteInvoiceItemCustomFieldsParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the delete invoice item custom fields params
 func (o *DeleteInvoiceItemCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete invoice item custom fields params
-func (o *DeleteInvoiceItemCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete invoice item custom fields params
-func (o *DeleteInvoiceItemCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete invoice item custom fields params
-func (o *DeleteInvoiceItemCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete invoice item custom fields params
-func (o *DeleteInvoiceItemCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete invoice item custom fields params
@@ -202,16 +176,6 @@ func (o *DeleteInvoiceItemCustomFieldsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_item/delete_invoice_item_tags_parameters.go
+++ b/kbclient/invoice_item/delete_invoice_item_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete invoice item tags operation typically these are written to a http
 */
 type DeleteInvoiceItemTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteInvoiceItemTagsParams) WithHTTPClient(client *http.Client) *Delet
 // SetHTTPClient adds the HTTPClient to the delete invoice item tags params
 func (o *DeleteInvoiceItemTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete invoice item tags params
-func (o *DeleteInvoiceItemTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteInvoiceItemTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete invoice item tags params
-func (o *DeleteInvoiceItemTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete invoice item tags params
-func (o *DeleteInvoiceItemTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteInvoiceItemTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete invoice item tags params
-func (o *DeleteInvoiceItemTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete invoice item tags params
@@ -202,16 +176,6 @@ func (o *DeleteInvoiceItemTagsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_item/get_invoice_item_custom_fields_parameters.go
+++ b/kbclient/invoice_item/get_invoice_item_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get invoice item custom fields operation typically these are written to 
 */
 type GetInvoiceItemCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*InvoiceItemID*/
@@ -123,28 +119,6 @@ func (o *GetInvoiceItemCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice item custom fields params
-func (o *GetInvoiceItemCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice item custom fields params
-func (o *GetInvoiceItemCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice item custom fields params
-func (o *GetInvoiceItemCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice item custom fields params
-func (o *GetInvoiceItemCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get invoice item custom fields params
 func (o *GetInvoiceItemCustomFieldsParams) WithAudit(audit *string) *GetInvoiceItemCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetInvoiceItemCustomFieldsParams) WriteToRequest(r runtime.ClientReques
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice_item/get_invoice_item_tags_parameters.go
+++ b/kbclient/invoice_item/get_invoice_item_tags_parameters.go
@@ -83,10 +83,6 @@ for the get invoice item tags operation typically these are written to a http.Re
 */
 type GetInvoiceItemTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*AccountID*/
 	AccountID strfmt.UUID
 	/*Audit*/
@@ -134,28 +130,6 @@ func (o *GetInvoiceItemTagsParams) WithHTTPClient(client *http.Client) *GetInvoi
 // SetHTTPClient adds the HTTPClient to the get invoice item tags params
 func (o *GetInvoiceItemTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice item tags params
-func (o *GetInvoiceItemTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoiceItemTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice item tags params
-func (o *GetInvoiceItemTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice item tags params
-func (o *GetInvoiceItemTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoiceItemTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice item tags params
-func (o *GetInvoiceItemTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAccountID adds the accountID to the get invoice item tags params
@@ -209,16 +183,6 @@ func (o *GetInvoiceItemTagsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// query param accountId
 	qrAccountID := o.AccountID

--- a/kbclient/invoice_item/invoice_item_client.go
+++ b/kbclient/invoice_item/invoice_item_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -99,31 +95,18 @@ func (a *Client) CreateInvoiceItemCustomFields(ctx context.Context, params *Crea
 	getParams := NewCreateInvoiceItemCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -182,31 +165,18 @@ func (a *Client) CreateInvoiceItemTags(ctx context.Context, params *CreateInvoic
 	getParams := NewCreateInvoiceItemTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -263,14 +233,6 @@ func (a *Client) DeleteInvoiceItemCustomFields(ctx context.Context, params *Dele
 		params = NewDeleteInvoiceItemCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -316,14 +278,6 @@ func (a *Client) DeleteInvoiceItemTags(ctx context.Context, params *DeleteInvoic
 		params = NewDeleteInvoiceItemTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -369,14 +323,6 @@ func (a *Client) GetInvoiceItemCustomFields(ctx context.Context, params *GetInvo
 		params = NewGetInvoiceItemCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -410,14 +356,6 @@ func (a *Client) GetInvoiceItemTags(ctx context.Context, params *GetInvoiceItemT
 		params = NewGetInvoiceItemTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -451,14 +389,6 @@ func (a *Client) ModifyInvoiceItemCustomFields(ctx context.Context, params *Modi
 		params = NewModifyInvoiceItemCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/invoice_item/modify_invoice_item_custom_fields_parameters.go
+++ b/kbclient/invoice_item/modify_invoice_item_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify invoice item custom fields operation typically these are written 
 */
 type ModifyInvoiceItemCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyInvoiceItemCustomFieldsParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the modify invoice item custom fields params
 func (o *ModifyInvoiceItemCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify invoice item custom fields params
-func (o *ModifyInvoiceItemCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify invoice item custom fields params
-func (o *ModifyInvoiceItemCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify invoice item custom fields params
-func (o *ModifyInvoiceItemCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyInvoiceItemCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify invoice item custom fields params
-func (o *ModifyInvoiceItemCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify invoice item custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyInvoiceItemCustomFieldsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_payment/complete_invoice_payment_transaction_parameters.go
+++ b/kbclient/invoice_payment/complete_invoice_payment_transaction_parameters.go
@@ -65,10 +65,6 @@ for the complete invoice payment transaction operation typically these are writt
 */
 type CompleteInvoicePaymentTransactionParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *CompleteInvoicePaymentTransactionParams) WithHTTPClient(client *http.Cl
 // SetHTTPClient adds the HTTPClient to the complete invoice payment transaction params
 func (o *CompleteInvoicePaymentTransactionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the complete invoice payment transaction params
-func (o *CompleteInvoicePaymentTransactionParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CompleteInvoicePaymentTransactionParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the complete invoice payment transaction params
-func (o *CompleteInvoicePaymentTransactionParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the complete invoice payment transaction params
-func (o *CompleteInvoicePaymentTransactionParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CompleteInvoicePaymentTransactionParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the complete invoice payment transaction params
-func (o *CompleteInvoicePaymentTransactionParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the complete invoice payment transaction params
@@ -230,16 +204,6 @@ func (o *CompleteInvoicePaymentTransactionParams) WriteToRequest(r runtime.Clien
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_payment/create_chargeback_parameters.go
+++ b/kbclient/invoice_payment/create_chargeback_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 
@@ -64,10 +65,6 @@ for the create chargeback operation typically these are written to a http.Reques
 */
 type CreateChargebackParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -78,6 +75,8 @@ type CreateChargebackParams struct {
 	Body *kbmodel.InvoicePaymentTransaction
 	/*PaymentID*/
 	PaymentID strfmt.UUID
+	/*PluginProperty*/
+	PluginProperty []string
 
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
@@ -117,28 +116,6 @@ func (o *CreateChargebackParams) WithHTTPClient(client *http.Client) *CreateChar
 // SetHTTPClient adds the HTTPClient to the create chargeback params
 func (o *CreateChargebackParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create chargeback params
-func (o *CreateChargebackParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateChargebackParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create chargeback params
-func (o *CreateChargebackParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create chargeback params
-func (o *CreateChargebackParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateChargebackParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create chargeback params
-func (o *CreateChargebackParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create chargeback params
@@ -196,6 +173,17 @@ func (o *CreateChargebackParams) SetPaymentID(paymentID strfmt.UUID) {
 	o.PaymentID = paymentID
 }
 
+// WithPluginProperty adds the pluginProperty to the create chargeback params
+func (o *CreateChargebackParams) WithPluginProperty(pluginProperty []string) *CreateChargebackParams {
+	o.SetPluginProperty(pluginProperty)
+	return o
+}
+
+// SetPluginProperty adds the pluginProperty to the create chargeback params
+func (o *CreateChargebackParams) SetPluginProperty(pluginProperty []string) {
+	o.PluginProperty = pluginProperty
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *CreateChargebackParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -203,16 +191,6 @@ func (o *CreateChargebackParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 
@@ -245,6 +223,14 @@ func (o *CreateChargebackParams) WriteToRequest(r runtime.ClientRequest, reg str
 
 	// path param paymentId
 	if err := r.SetPathParam("paymentId", o.PaymentID.String()); err != nil {
+		return err
+	}
+
+	valuesPluginProperty := o.PluginProperty
+
+	joinedPluginProperty := swag.JoinByFormat(valuesPluginProperty, "multi")
+	// query array param pluginProperty
+	if err := r.SetQueryParam("pluginProperty", joinedPluginProperty...); err != nil {
 		return err
 	}
 

--- a/kbclient/invoice_payment/create_chargeback_reversal_parameters.go
+++ b/kbclient/invoice_payment/create_chargeback_reversal_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 
@@ -64,10 +65,6 @@ for the create chargeback reversal operation typically these are written to a ht
 */
 type CreateChargebackReversalParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -78,6 +75,8 @@ type CreateChargebackReversalParams struct {
 	Body *kbmodel.InvoicePaymentTransaction
 	/*PaymentID*/
 	PaymentID strfmt.UUID
+	/*PluginProperty*/
+	PluginProperty []string
 
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
@@ -117,28 +116,6 @@ func (o *CreateChargebackReversalParams) WithHTTPClient(client *http.Client) *Cr
 // SetHTTPClient adds the HTTPClient to the create chargeback reversal params
 func (o *CreateChargebackReversalParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create chargeback reversal params
-func (o *CreateChargebackReversalParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateChargebackReversalParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create chargeback reversal params
-func (o *CreateChargebackReversalParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create chargeback reversal params
-func (o *CreateChargebackReversalParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateChargebackReversalParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create chargeback reversal params
-func (o *CreateChargebackReversalParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create chargeback reversal params
@@ -196,6 +173,17 @@ func (o *CreateChargebackReversalParams) SetPaymentID(paymentID strfmt.UUID) {
 	o.PaymentID = paymentID
 }
 
+// WithPluginProperty adds the pluginProperty to the create chargeback reversal params
+func (o *CreateChargebackReversalParams) WithPluginProperty(pluginProperty []string) *CreateChargebackReversalParams {
+	o.SetPluginProperty(pluginProperty)
+	return o
+}
+
+// SetPluginProperty adds the pluginProperty to the create chargeback reversal params
+func (o *CreateChargebackReversalParams) SetPluginProperty(pluginProperty []string) {
+	o.PluginProperty = pluginProperty
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *CreateChargebackReversalParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -203,16 +191,6 @@ func (o *CreateChargebackReversalParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 
@@ -245,6 +223,14 @@ func (o *CreateChargebackReversalParams) WriteToRequest(r runtime.ClientRequest,
 
 	// path param paymentId
 	if err := r.SetPathParam("paymentId", o.PaymentID.String()); err != nil {
+		return err
+	}
+
+	valuesPluginProperty := o.PluginProperty
+
+	joinedPluginProperty := swag.JoinByFormat(valuesPluginProperty, "multi")
+	// query array param pluginProperty
+	if err := r.SetQueryParam("pluginProperty", joinedPluginProperty...); err != nil {
 		return err
 	}
 

--- a/kbclient/invoice_payment/create_invoice_payment_custom_fields_parameters.go
+++ b/kbclient/invoice_payment/create_invoice_payment_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create invoice payment custom fields operation typically these are writt
 */
 type CreateInvoicePaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreateInvoicePaymentCustomFieldsParams) WithHTTPClient(client *http.Cli
 // SetHTTPClient adds the HTTPClient to the create invoice payment custom fields params
 func (o *CreateInvoicePaymentCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create invoice payment custom fields params
-func (o *CreateInvoicePaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create invoice payment custom fields params
-func (o *CreateInvoicePaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create invoice payment custom fields params
-func (o *CreateInvoicePaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create invoice payment custom fields params
-func (o *CreateInvoicePaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create invoice payment custom fields params
@@ -203,16 +177,6 @@ func (o *CreateInvoicePaymentCustomFieldsParams) WriteToRequest(r runtime.Client
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_payment/create_invoice_payment_tags_parameters.go
+++ b/kbclient/invoice_payment/create_invoice_payment_tags_parameters.go
@@ -62,10 +62,6 @@ for the create invoice payment tags operation typically these are written to a h
 */
 type CreateInvoicePaymentTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateInvoicePaymentTagsParams) WithHTTPClient(client *http.Client) *Cr
 // SetHTTPClient adds the HTTPClient to the create invoice payment tags params
 func (o *CreateInvoicePaymentTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create invoice payment tags params
-func (o *CreateInvoicePaymentTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateInvoicePaymentTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create invoice payment tags params
-func (o *CreateInvoicePaymentTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create invoice payment tags params
-func (o *CreateInvoicePaymentTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateInvoicePaymentTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create invoice payment tags params
-func (o *CreateInvoicePaymentTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create invoice payment tags params
@@ -201,16 +175,6 @@ func (o *CreateInvoicePaymentTagsParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_payment/create_refund_with_adjustments_parameters.go
+++ b/kbclient/invoice_payment/create_refund_with_adjustments_parameters.go
@@ -77,10 +77,6 @@ for the create refund with adjustments operation typically these are written to 
 */
 type CreateRefundWithAdjustmentsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -136,28 +132,6 @@ func (o *CreateRefundWithAdjustmentsParams) WithHTTPClient(client *http.Client) 
 // SetHTTPClient adds the HTTPClient to the create refund with adjustments params
 func (o *CreateRefundWithAdjustmentsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create refund with adjustments params
-func (o *CreateRefundWithAdjustmentsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateRefundWithAdjustmentsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create refund with adjustments params
-func (o *CreateRefundWithAdjustmentsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create refund with adjustments params
-func (o *CreateRefundWithAdjustmentsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateRefundWithAdjustmentsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create refund with adjustments params
-func (o *CreateRefundWithAdjustmentsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create refund with adjustments params
@@ -255,16 +229,6 @@ func (o *CreateRefundWithAdjustmentsParams) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_payment/delete_invoice_payment_custom_fields_parameters.go
+++ b/kbclient/invoice_payment/delete_invoice_payment_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete invoice payment custom fields operation typically these are writt
 */
 type DeleteInvoicePaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteInvoicePaymentCustomFieldsParams) WithHTTPClient(client *http.Cli
 // SetHTTPClient adds the HTTPClient to the delete invoice payment custom fields params
 func (o *DeleteInvoicePaymentCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete invoice payment custom fields params
-func (o *DeleteInvoicePaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete invoice payment custom fields params
-func (o *DeleteInvoicePaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete invoice payment custom fields params
-func (o *DeleteInvoicePaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete invoice payment custom fields params
-func (o *DeleteInvoicePaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete invoice payment custom fields params
@@ -202,16 +176,6 @@ func (o *DeleteInvoicePaymentCustomFieldsParams) WriteToRequest(r runtime.Client
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_payment/delete_invoice_payment_tags_parameters.go
+++ b/kbclient/invoice_payment/delete_invoice_payment_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete invoice payment tags operation typically these are written to a h
 */
 type DeleteInvoicePaymentTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteInvoicePaymentTagsParams) WithHTTPClient(client *http.Client) *De
 // SetHTTPClient adds the HTTPClient to the delete invoice payment tags params
 func (o *DeleteInvoicePaymentTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete invoice payment tags params
-func (o *DeleteInvoicePaymentTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteInvoicePaymentTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete invoice payment tags params
-func (o *DeleteInvoicePaymentTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete invoice payment tags params
-func (o *DeleteInvoicePaymentTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteInvoicePaymentTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete invoice payment tags params
-func (o *DeleteInvoicePaymentTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete invoice payment tags params
@@ -202,16 +176,6 @@ func (o *DeleteInvoicePaymentTagsParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/invoice_payment/get_invoice_payment_custom_fields_parameters.go
+++ b/kbclient/invoice_payment/get_invoice_payment_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get invoice payment custom fields operation typically these are written 
 */
 type GetInvoicePaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*PaymentID*/
@@ -123,28 +119,6 @@ func (o *GetInvoicePaymentCustomFieldsParams) SetHTTPClient(client *http.Client)
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice payment custom fields params
-func (o *GetInvoicePaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice payment custom fields params
-func (o *GetInvoicePaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice payment custom fields params
-func (o *GetInvoicePaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice payment custom fields params
-func (o *GetInvoicePaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get invoice payment custom fields params
 func (o *GetInvoicePaymentCustomFieldsParams) WithAudit(audit *string) *GetInvoicePaymentCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetInvoicePaymentCustomFieldsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice_payment/get_invoice_payment_parameters.go
+++ b/kbclient/invoice_payment/get_invoice_payment_parameters.go
@@ -91,10 +91,6 @@ for the get invoice payment operation typically these are written to a http.Requ
 */
 type GetInvoicePaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*PaymentID*/
@@ -144,28 +140,6 @@ func (o *GetInvoicePaymentParams) WithHTTPClient(client *http.Client) *GetInvoic
 // SetHTTPClient adds the HTTPClient to the get invoice payment params
 func (o *GetInvoicePaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice payment params
-func (o *GetInvoicePaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoicePaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice payment params
-func (o *GetInvoicePaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice payment params
-func (o *GetInvoicePaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoicePaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice payment params
-func (o *GetInvoicePaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get invoice payment params
@@ -230,16 +204,6 @@ func (o *GetInvoicePaymentParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice_payment/get_invoice_payment_tags_parameters.go
+++ b/kbclient/invoice_payment/get_invoice_payment_tags_parameters.go
@@ -83,10 +83,6 @@ for the get invoice payment tags operation typically these are written to a http
 */
 type GetInvoicePaymentTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*IncludedDeleted*/
@@ -134,28 +130,6 @@ func (o *GetInvoicePaymentTagsParams) WithHTTPClient(client *http.Client) *GetIn
 // SetHTTPClient adds the HTTPClient to the get invoice payment tags params
 func (o *GetInvoicePaymentTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get invoice payment tags params
-func (o *GetInvoicePaymentTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetInvoicePaymentTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get invoice payment tags params
-func (o *GetInvoicePaymentTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get invoice payment tags params
-func (o *GetInvoicePaymentTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetInvoicePaymentTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get invoice payment tags params
-func (o *GetInvoicePaymentTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get invoice payment tags params
@@ -209,16 +183,6 @@ func (o *GetInvoicePaymentTagsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/invoice_payment/invoice_payment_client.go
+++ b/kbclient/invoice_payment/invoice_payment_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -122,14 +118,6 @@ func (a *Client) CompleteInvoicePaymentTransaction(ctx context.Context, params *
 		params = NewCompleteInvoicePaymentTransactionParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -177,31 +165,18 @@ func (a *Client) CreateChargeback(ctx context.Context, params *CreateChargebackP
 	getParams := NewCreateChargebackParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -260,31 +235,18 @@ func (a *Client) CreateChargebackReversal(ctx context.Context, params *CreateCha
 	getParams := NewCreateChargebackReversalParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -343,31 +305,18 @@ func (a *Client) CreateInvoicePaymentCustomFields(ctx context.Context, params *C
 	getParams := NewCreateInvoicePaymentCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -426,31 +375,18 @@ func (a *Client) CreateInvoicePaymentTags(ctx context.Context, params *CreateInv
 	getParams := NewCreateInvoicePaymentTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -509,31 +445,18 @@ func (a *Client) CreateRefundWithAdjustments(ctx context.Context, params *Create
 	getParams := NewCreateRefundWithAdjustmentsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -590,14 +513,6 @@ func (a *Client) DeleteInvoicePaymentCustomFields(ctx context.Context, params *D
 		params = NewDeleteInvoicePaymentCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -643,14 +558,6 @@ func (a *Client) DeleteInvoicePaymentTags(ctx context.Context, params *DeleteInv
 		params = NewDeleteInvoicePaymentTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -696,14 +603,6 @@ func (a *Client) GetInvoicePayment(ctx context.Context, params *GetInvoicePaymen
 		params = NewGetInvoicePaymentParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -737,14 +636,6 @@ func (a *Client) GetInvoicePaymentCustomFields(ctx context.Context, params *GetI
 		params = NewGetInvoicePaymentCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -778,14 +669,6 @@ func (a *Client) GetInvoicePaymentTags(ctx context.Context, params *GetInvoicePa
 		params = NewGetInvoicePaymentTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -819,14 +702,6 @@ func (a *Client) ModifyInvoicePaymentCustomFields(ctx context.Context, params *M
 		params = NewModifyInvoicePaymentCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/invoice_payment/modify_invoice_payment_custom_fields_parameters.go
+++ b/kbclient/invoice_payment/modify_invoice_payment_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify invoice payment custom fields operation typically these are writt
 */
 type ModifyInvoicePaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyInvoicePaymentCustomFieldsParams) WithHTTPClient(client *http.Cli
 // SetHTTPClient adds the HTTPClient to the modify invoice payment custom fields params
 func (o *ModifyInvoicePaymentCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify invoice payment custom fields params
-func (o *ModifyInvoicePaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify invoice payment custom fields params
-func (o *ModifyInvoicePaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify invoice payment custom fields params
-func (o *ModifyInvoicePaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyInvoicePaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify invoice payment custom fields params
-func (o *ModifyInvoicePaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify invoice payment custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyInvoicePaymentCustomFieldsParams) WriteToRequest(r runtime.Client
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/kill_bill_client.go
+++ b/kbclient/kill_bill_client.go
@@ -259,10 +259,6 @@ func (c *KillBill) SetDefaults(defaults KillbillDefaults) {
 
 // Implements killbill default values.
 type KillbillDefaults struct {
-	// XKillbillAPIKey property
-	APIKey *string
-	// XKillbillAPISecret property
-	APISecret *string
 	// XKillbillCreatedBy property
 	CreatedBy *string
 	// XKillbillComment property
@@ -271,16 +267,6 @@ type KillbillDefaults struct {
 	Reason *string
 	// withStackTrace property
 	WithStackTrace *bool
-}
-
-// Default API Key. If not set explicitly in params, this will be used.
-func (d KillbillDefaults) XKillbillAPIKey() *string {
-	return d.APIKey
-}
-
-// Default API Secret. If not set explicitly in params, this will be used.
-func (d KillbillDefaults) XKillbillAPISecret() *string {
-	return d.APISecret
 }
 
 // Default CreatedBy. If not set explicitly in params, this will be used.

--- a/kbclient/nodes_info/nodes_info_client.go
+++ b/kbclient/nodes_info/nodes_info_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -104,7 +100,6 @@ func (a *Client) TriggerNodeCommand(ctx context.Context, params *TriggerNodeComm
 		params = NewTriggerNodeCommandParams()
 	}
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/overdue/get_overdue_config_json_parameters.go
+++ b/kbclient/overdue/get_overdue_config_json_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewGetOverdueConfigJSONParams creates a new GetOverdueConfigJSONParams object
 // with the default values initialized.
 func NewGetOverdueConfigJSONParams() *GetOverdueConfigJSONParams {
-	var ()
+
 	return &GetOverdueConfigJSONParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewGetOverdueConfigJSONParams() *GetOverdueConfigJSONParams {
 // NewGetOverdueConfigJSONParamsWithTimeout creates a new GetOverdueConfigJSONParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetOverdueConfigJSONParamsWithTimeout(timeout time.Duration) *GetOverdueConfigJSONParams {
-	var ()
+
 	return &GetOverdueConfigJSONParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewGetOverdueConfigJSONParamsWithTimeout(timeout time.Duration) *GetOverdue
 // NewGetOverdueConfigJSONParamsWithContext creates a new GetOverdueConfigJSONParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetOverdueConfigJSONParamsWithContext(ctx context.Context) *GetOverdueConfigJSONParams {
-	var ()
+
 	return &GetOverdueConfigJSONParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewGetOverdueConfigJSONParamsWithContext(ctx context.Context) *GetOverdueCo
 // NewGetOverdueConfigJSONParamsWithHTTPClient creates a new GetOverdueConfigJSONParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetOverdueConfigJSONParamsWithHTTPClient(client *http.Client) *GetOverdueConfigJSONParams {
-	var ()
+
 	return &GetOverdueConfigJSONParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewGetOverdueConfigJSONParamsWithHTTPClient(client *http.Client) *GetOverdu
 for the get overdue config Json operation typically these are written to a http.Request
 */
 type GetOverdueConfigJSONParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *GetOverdueConfigJSONParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get overdue config Json params
-func (o *GetOverdueConfigJSONParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetOverdueConfigJSONParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get overdue config Json params
-func (o *GetOverdueConfigJSONParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get overdue config Json params
-func (o *GetOverdueConfigJSONParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetOverdueConfigJSONParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get overdue config Json params
-func (o *GetOverdueConfigJSONParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *GetOverdueConfigJSONParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *GetOverdueConfigJSONParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/overdue/get_overdue_config_xml_parameters.go
+++ b/kbclient/overdue/get_overdue_config_xml_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewGetOverdueConfigXMLParams creates a new GetOverdueConfigXMLParams object
 // with the default values initialized.
 func NewGetOverdueConfigXMLParams() *GetOverdueConfigXMLParams {
-	var ()
+
 	return &GetOverdueConfigXMLParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewGetOverdueConfigXMLParams() *GetOverdueConfigXMLParams {
 // NewGetOverdueConfigXMLParamsWithTimeout creates a new GetOverdueConfigXMLParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetOverdueConfigXMLParamsWithTimeout(timeout time.Duration) *GetOverdueConfigXMLParams {
-	var ()
+
 	return &GetOverdueConfigXMLParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewGetOverdueConfigXMLParamsWithTimeout(timeout time.Duration) *GetOverdueC
 // NewGetOverdueConfigXMLParamsWithContext creates a new GetOverdueConfigXMLParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetOverdueConfigXMLParamsWithContext(ctx context.Context) *GetOverdueConfigXMLParams {
-	var ()
+
 	return &GetOverdueConfigXMLParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewGetOverdueConfigXMLParamsWithContext(ctx context.Context) *GetOverdueCon
 // NewGetOverdueConfigXMLParamsWithHTTPClient creates a new GetOverdueConfigXMLParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetOverdueConfigXMLParamsWithHTTPClient(client *http.Client) *GetOverdueConfigXMLParams {
-	var ()
+
 	return &GetOverdueConfigXMLParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewGetOverdueConfigXMLParamsWithHTTPClient(client *http.Client) *GetOverdue
 for the get overdue config Xml operation typically these are written to a http.Request
 */
 type GetOverdueConfigXMLParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *GetOverdueConfigXMLParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get overdue config Xml params
-func (o *GetOverdueConfigXMLParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetOverdueConfigXMLParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get overdue config Xml params
-func (o *GetOverdueConfigXMLParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get overdue config Xml params
-func (o *GetOverdueConfigXMLParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetOverdueConfigXMLParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get overdue config Xml params
-func (o *GetOverdueConfigXMLParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *GetOverdueConfigXMLParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *GetOverdueConfigXMLParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/overdue/overdue_client.go
+++ b/kbclient/overdue/overdue_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -82,14 +78,6 @@ func (a *Client) GetOverdueConfigJSON(ctx context.Context, params *GetOverdueCon
 		params = NewGetOverdueConfigJSONParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -123,14 +111,6 @@ func (a *Client) GetOverdueConfigXML(ctx context.Context, params *GetOverdueConf
 		params = NewGetOverdueConfigXMLParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -166,31 +146,18 @@ func (a *Client) UploadOverdueConfigJSON(ctx context.Context, params *UploadOver
 	getParams := NewUploadOverdueConfigJSONParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -249,31 +216,18 @@ func (a *Client) UploadOverdueConfigXML(ctx context.Context, params *UploadOverd
 	getParams := NewUploadOverdueConfigXMLParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/overdue/upload_overdue_config_json_parameters.go
+++ b/kbclient/overdue/upload_overdue_config_json_parameters.go
@@ -64,10 +64,6 @@ for the upload overdue config Json operation typically these are written to a ht
 */
 type UploadOverdueConfigJSONParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *UploadOverdueConfigJSONParams) WithHTTPClient(client *http.Client) *Upl
 // SetHTTPClient adds the HTTPClient to the upload overdue config Json params
 func (o *UploadOverdueConfigJSONParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload overdue config Json params
-func (o *UploadOverdueConfigJSONParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadOverdueConfigJSONParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload overdue config Json params
-func (o *UploadOverdueConfigJSONParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload overdue config Json params
-func (o *UploadOverdueConfigJSONParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadOverdueConfigJSONParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload overdue config Json params
-func (o *UploadOverdueConfigJSONParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload overdue config Json params
@@ -190,16 +164,6 @@ func (o *UploadOverdueConfigJSONParams) WriteToRequest(r runtime.ClientRequest, 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/overdue/upload_overdue_config_xml_parameters.go
+++ b/kbclient/overdue/upload_overdue_config_xml_parameters.go
@@ -62,10 +62,6 @@ for the upload overdue config Xml operation typically these are written to a htt
 */
 type UploadOverdueConfigXMLParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *UploadOverdueConfigXMLParams) WithHTTPClient(client *http.Client) *Uplo
 // SetHTTPClient adds the HTTPClient to the upload overdue config Xml params
 func (o *UploadOverdueConfigXMLParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload overdue config Xml params
-func (o *UploadOverdueConfigXMLParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadOverdueConfigXMLParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload overdue config Xml params
-func (o *UploadOverdueConfigXMLParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload overdue config Xml params
-func (o *UploadOverdueConfigXMLParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadOverdueConfigXMLParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload overdue config Xml params
-func (o *UploadOverdueConfigXMLParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload overdue config Xml params
@@ -188,16 +162,6 @@ func (o *UploadOverdueConfigXMLParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/cancel_scheduled_payment_transaction_by_external_key_parameters.go
+++ b/kbclient/payment/cancel_scheduled_payment_transaction_by_external_key_parameters.go
@@ -62,10 +62,6 @@ for the cancel scheduled payment transaction by external key operation typically
 */
 type CancelScheduledPaymentTransactionByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *CancelScheduledPaymentTransactionByExternalKeyParams) WithHTTPClient(cl
 // SetHTTPClient adds the HTTPClient to the cancel scheduled payment transaction by external key params
 func (o *CancelScheduledPaymentTransactionByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the cancel scheduled payment transaction by external key params
-func (o *CancelScheduledPaymentTransactionByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CancelScheduledPaymentTransactionByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the cancel scheduled payment transaction by external key params
-func (o *CancelScheduledPaymentTransactionByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the cancel scheduled payment transaction by external key params
-func (o *CancelScheduledPaymentTransactionByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CancelScheduledPaymentTransactionByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the cancel scheduled payment transaction by external key params
-func (o *CancelScheduledPaymentTransactionByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the cancel scheduled payment transaction by external key params
@@ -188,16 +162,6 @@ func (o *CancelScheduledPaymentTransactionByExternalKeyParams) WriteToRequest(r 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/cancel_scheduled_payment_transaction_by_id_parameters.go
+++ b/kbclient/payment/cancel_scheduled_payment_transaction_by_id_parameters.go
@@ -62,10 +62,6 @@ for the cancel scheduled payment transaction by Id operation typically these are
 */
 type CancelScheduledPaymentTransactionByIDParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *CancelScheduledPaymentTransactionByIDParams) WithHTTPClient(client *htt
 // SetHTTPClient adds the HTTPClient to the cancel scheduled payment transaction by Id params
 func (o *CancelScheduledPaymentTransactionByIDParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the cancel scheduled payment transaction by Id params
-func (o *CancelScheduledPaymentTransactionByIDParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CancelScheduledPaymentTransactionByIDParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the cancel scheduled payment transaction by Id params
-func (o *CancelScheduledPaymentTransactionByIDParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the cancel scheduled payment transaction by Id params
-func (o *CancelScheduledPaymentTransactionByIDParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CancelScheduledPaymentTransactionByIDParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the cancel scheduled payment transaction by Id params
-func (o *CancelScheduledPaymentTransactionByIDParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the cancel scheduled payment transaction by Id params
@@ -188,16 +162,6 @@ func (o *CancelScheduledPaymentTransactionByIDParams) WriteToRequest(r runtime.C
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/capture_authorization_by_external_key_parameters.go
+++ b/kbclient/payment/capture_authorization_by_external_key_parameters.go
@@ -65,10 +65,6 @@ for the capture authorization by external key operation typically these are writ
 */
 type CaptureAuthorizationByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *CaptureAuthorizationByExternalKeyParams) WithHTTPClient(client *http.Cl
 // SetHTTPClient adds the HTTPClient to the capture authorization by external key params
 func (o *CaptureAuthorizationByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the capture authorization by external key params
-func (o *CaptureAuthorizationByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CaptureAuthorizationByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the capture authorization by external key params
-func (o *CaptureAuthorizationByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the capture authorization by external key params
-func (o *CaptureAuthorizationByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CaptureAuthorizationByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the capture authorization by external key params
-func (o *CaptureAuthorizationByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the capture authorization by external key params
@@ -217,16 +191,6 @@ func (o *CaptureAuthorizationByExternalKeyParams) WriteToRequest(r runtime.Clien
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/capture_authorization_parameters.go
+++ b/kbclient/payment/capture_authorization_parameters.go
@@ -65,10 +65,6 @@ for the capture authorization operation typically these are written to a http.Re
 */
 type CaptureAuthorizationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *CaptureAuthorizationParams) WithHTTPClient(client *http.Client) *Captur
 // SetHTTPClient adds the HTTPClient to the capture authorization params
 func (o *CaptureAuthorizationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the capture authorization params
-func (o *CaptureAuthorizationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CaptureAuthorizationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the capture authorization params
-func (o *CaptureAuthorizationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the capture authorization params
-func (o *CaptureAuthorizationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CaptureAuthorizationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the capture authorization params
-func (o *CaptureAuthorizationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the capture authorization params
@@ -230,16 +204,6 @@ func (o *CaptureAuthorizationParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/chargeback_payment_by_external_key_parameters.go
+++ b/kbclient/payment/chargeback_payment_by_external_key_parameters.go
@@ -65,10 +65,6 @@ for the chargeback payment by external key operation typically these are written
 */
 type ChargebackPaymentByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *ChargebackPaymentByExternalKeyParams) WithHTTPClient(client *http.Clien
 // SetHTTPClient adds the HTTPClient to the chargeback payment by external key params
 func (o *ChargebackPaymentByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the chargeback payment by external key params
-func (o *ChargebackPaymentByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ChargebackPaymentByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the chargeback payment by external key params
-func (o *ChargebackPaymentByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the chargeback payment by external key params
-func (o *ChargebackPaymentByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ChargebackPaymentByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the chargeback payment by external key params
-func (o *ChargebackPaymentByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the chargeback payment by external key params
@@ -217,16 +191,6 @@ func (o *ChargebackPaymentByExternalKeyParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/chargeback_payment_parameters.go
+++ b/kbclient/payment/chargeback_payment_parameters.go
@@ -65,10 +65,6 @@ for the chargeback payment operation typically these are written to a http.Reque
 */
 type ChargebackPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *ChargebackPaymentParams) WithHTTPClient(client *http.Client) *Chargebac
 // SetHTTPClient adds the HTTPClient to the chargeback payment params
 func (o *ChargebackPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the chargeback payment params
-func (o *ChargebackPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ChargebackPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the chargeback payment params
-func (o *ChargebackPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the chargeback payment params
-func (o *ChargebackPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ChargebackPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the chargeback payment params
-func (o *ChargebackPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the chargeback payment params
@@ -230,16 +204,6 @@ func (o *ChargebackPaymentParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/chargeback_reversal_payment_by_external_key_parameters.go
+++ b/kbclient/payment/chargeback_reversal_payment_by_external_key_parameters.go
@@ -65,10 +65,6 @@ for the chargeback reversal payment by external key operation typically these ar
 */
 type ChargebackReversalPaymentByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *ChargebackReversalPaymentByExternalKeyParams) WithHTTPClient(client *ht
 // SetHTTPClient adds the HTTPClient to the chargeback reversal payment by external key params
 func (o *ChargebackReversalPaymentByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the chargeback reversal payment by external key params
-func (o *ChargebackReversalPaymentByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ChargebackReversalPaymentByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the chargeback reversal payment by external key params
-func (o *ChargebackReversalPaymentByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the chargeback reversal payment by external key params
-func (o *ChargebackReversalPaymentByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ChargebackReversalPaymentByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the chargeback reversal payment by external key params
-func (o *ChargebackReversalPaymentByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the chargeback reversal payment by external key params
@@ -217,16 +191,6 @@ func (o *ChargebackReversalPaymentByExternalKeyParams) WriteToRequest(r runtime.
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/chargeback_reversal_payment_parameters.go
+++ b/kbclient/payment/chargeback_reversal_payment_parameters.go
@@ -65,10 +65,6 @@ for the chargeback reversal payment operation typically these are written to a h
 */
 type ChargebackReversalPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *ChargebackReversalPaymentParams) WithHTTPClient(client *http.Client) *C
 // SetHTTPClient adds the HTTPClient to the chargeback reversal payment params
 func (o *ChargebackReversalPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the chargeback reversal payment params
-func (o *ChargebackReversalPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ChargebackReversalPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the chargeback reversal payment params
-func (o *ChargebackReversalPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the chargeback reversal payment params
-func (o *ChargebackReversalPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ChargebackReversalPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the chargeback reversal payment params
-func (o *ChargebackReversalPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the chargeback reversal payment params
@@ -230,16 +204,6 @@ func (o *ChargebackReversalPaymentParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/complete_transaction_by_external_key_parameters.go
+++ b/kbclient/payment/complete_transaction_by_external_key_parameters.go
@@ -65,10 +65,6 @@ for the complete transaction by external key operation typically these are writt
 */
 type CompleteTransactionByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *CompleteTransactionByExternalKeyParams) WithHTTPClient(client *http.Cli
 // SetHTTPClient adds the HTTPClient to the complete transaction by external key params
 func (o *CompleteTransactionByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the complete transaction by external key params
-func (o *CompleteTransactionByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CompleteTransactionByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the complete transaction by external key params
-func (o *CompleteTransactionByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the complete transaction by external key params
-func (o *CompleteTransactionByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CompleteTransactionByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the complete transaction by external key params
-func (o *CompleteTransactionByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the complete transaction by external key params
@@ -217,16 +191,6 @@ func (o *CompleteTransactionByExternalKeyParams) WriteToRequest(r runtime.Client
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/complete_transaction_parameters.go
+++ b/kbclient/payment/complete_transaction_parameters.go
@@ -65,10 +65,6 @@ for the complete transaction operation typically these are written to a http.Req
 */
 type CompleteTransactionParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *CompleteTransactionParams) WithHTTPClient(client *http.Client) *Complet
 // SetHTTPClient adds the HTTPClient to the complete transaction params
 func (o *CompleteTransactionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the complete transaction params
-func (o *CompleteTransactionParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CompleteTransactionParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the complete transaction params
-func (o *CompleteTransactionParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the complete transaction params
-func (o *CompleteTransactionParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CompleteTransactionParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the complete transaction params
-func (o *CompleteTransactionParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the complete transaction params
@@ -230,16 +204,6 @@ func (o *CompleteTransactionParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/create_combo_payment_parameters.go
+++ b/kbclient/payment/create_combo_payment_parameters.go
@@ -65,10 +65,6 @@ for the create combo payment operation typically these are written to a http.Req
 */
 type CreateComboPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -118,28 +114,6 @@ func (o *CreateComboPaymentParams) WithHTTPClient(client *http.Client) *CreateCo
 // SetHTTPClient adds the HTTPClient to the create combo payment params
 func (o *CreateComboPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create combo payment params
-func (o *CreateComboPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateComboPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create combo payment params
-func (o *CreateComboPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create combo payment params
-func (o *CreateComboPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateComboPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create combo payment params
-func (o *CreateComboPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create combo payment params
@@ -204,16 +178,6 @@ func (o *CreateComboPaymentParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/create_payment_custom_fields_parameters.go
+++ b/kbclient/payment/create_payment_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create payment custom fields operation typically these are written to a 
 */
 type CreatePaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreatePaymentCustomFieldsParams) WithHTTPClient(client *http.Client) *C
 // SetHTTPClient adds the HTTPClient to the create payment custom fields params
 func (o *CreatePaymentCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create payment custom fields params
-func (o *CreatePaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreatePaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create payment custom fields params
-func (o *CreatePaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create payment custom fields params
-func (o *CreatePaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreatePaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create payment custom fields params
-func (o *CreatePaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create payment custom fields params
@@ -203,16 +177,6 @@ func (o *CreatePaymentCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/create_payment_tags_parameters.go
+++ b/kbclient/payment/create_payment_tags_parameters.go
@@ -62,10 +62,6 @@ for the create payment tags operation typically these are written to a http.Requ
 */
 type CreatePaymentTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreatePaymentTagsParams) WithHTTPClient(client *http.Client) *CreatePay
 // SetHTTPClient adds the HTTPClient to the create payment tags params
 func (o *CreatePaymentTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create payment tags params
-func (o *CreatePaymentTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreatePaymentTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create payment tags params
-func (o *CreatePaymentTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create payment tags params
-func (o *CreatePaymentTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreatePaymentTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create payment tags params
-func (o *CreatePaymentTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create payment tags params
@@ -201,16 +175,6 @@ func (o *CreatePaymentTagsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/delete_payment_custom_fields_parameters.go
+++ b/kbclient/payment/delete_payment_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete payment custom fields operation typically these are written to a 
 */
 type DeletePaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeletePaymentCustomFieldsParams) WithHTTPClient(client *http.Client) *D
 // SetHTTPClient adds the HTTPClient to the delete payment custom fields params
 func (o *DeletePaymentCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete payment custom fields params
-func (o *DeletePaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete payment custom fields params
-func (o *DeletePaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete payment custom fields params
-func (o *DeletePaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete payment custom fields params
-func (o *DeletePaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete payment custom fields params
@@ -202,16 +176,6 @@ func (o *DeletePaymentCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/delete_payment_tags_parameters.go
+++ b/kbclient/payment/delete_payment_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete payment tags operation typically these are written to a http.Requ
 */
 type DeletePaymentTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeletePaymentTagsParams) WithHTTPClient(client *http.Client) *DeletePay
 // SetHTTPClient adds the HTTPClient to the delete payment tags params
 func (o *DeletePaymentTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete payment tags params
-func (o *DeletePaymentTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePaymentTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete payment tags params
-func (o *DeletePaymentTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete payment tags params
-func (o *DeletePaymentTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePaymentTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete payment tags params
-func (o *DeletePaymentTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete payment tags params
@@ -202,16 +176,6 @@ func (o *DeletePaymentTagsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/get_payment_attempt_audit_logs_with_history_parameters.go
+++ b/kbclient/payment/get_payment_attempt_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get payment attempt audit logs with history operation typically these ar
 */
 type GetPaymentAttemptAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*PaymentAttemptID*/
 	PaymentAttemptID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetPaymentAttemptAuditLogsWithHistoryParams) SetHTTPClient(client *http
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment attempt audit logs with history params
-func (o *GetPaymentAttemptAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentAttemptAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment attempt audit logs with history params
-func (o *GetPaymentAttemptAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment attempt audit logs with history params
-func (o *GetPaymentAttemptAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentAttemptAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment attempt audit logs with history params
-func (o *GetPaymentAttemptAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithPaymentAttemptID adds the paymentAttemptID to the get payment attempt audit logs with history params
 func (o *GetPaymentAttemptAuditLogsWithHistoryParams) WithPaymentAttemptID(paymentAttemptID strfmt.UUID) *GetPaymentAttemptAuditLogsWithHistoryParams {
 	o.SetPaymentAttemptID(paymentAttemptID)
@@ -149,16 +123,6 @@ func (o *GetPaymentAttemptAuditLogsWithHistoryParams) WriteToRequest(r runtime.C
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param paymentAttemptId
 	if err := r.SetPathParam("paymentAttemptId", o.PaymentAttemptID.String()); err != nil {

--- a/kbclient/payment/get_payment_audit_logs_with_history_parameters.go
+++ b/kbclient/payment/get_payment_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get payment audit logs with history operation typically these are writte
 */
 type GetPaymentAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*PaymentID*/
 	PaymentID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetPaymentAuditLogsWithHistoryParams) SetHTTPClient(client *http.Client
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment audit logs with history params
-func (o *GetPaymentAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment audit logs with history params
-func (o *GetPaymentAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment audit logs with history params
-func (o *GetPaymentAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment audit logs with history params
-func (o *GetPaymentAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithPaymentID adds the paymentID to the get payment audit logs with history params
 func (o *GetPaymentAuditLogsWithHistoryParams) WithPaymentID(paymentID strfmt.UUID) *GetPaymentAuditLogsWithHistoryParams {
 	o.SetPaymentID(paymentID)
@@ -149,16 +123,6 @@ func (o *GetPaymentAuditLogsWithHistoryParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param paymentId
 	if err := r.SetPathParam("paymentId", o.PaymentID.String()); err != nil {

--- a/kbclient/payment/get_payment_by_external_key_parameters.go
+++ b/kbclient/payment/get_payment_by_external_key_parameters.go
@@ -91,10 +91,6 @@ for the get payment by external key operation typically these are written to a h
 */
 type GetPaymentByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*ExternalKey*/
@@ -144,28 +140,6 @@ func (o *GetPaymentByExternalKeyParams) WithHTTPClient(client *http.Client) *Get
 // SetHTTPClient adds the HTTPClient to the get payment by external key params
 func (o *GetPaymentByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment by external key params
-func (o *GetPaymentByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment by external key params
-func (o *GetPaymentByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment by external key params
-func (o *GetPaymentByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment by external key params
-func (o *GetPaymentByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payment by external key params
@@ -230,16 +204,6 @@ func (o *GetPaymentByExternalKeyParams) WriteToRequest(r runtime.ClientRequest, 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment/get_payment_custom_fields_parameters.go
+++ b/kbclient/payment/get_payment_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get payment custom fields operation typically these are written to a htt
 */
 type GetPaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*PaymentID*/
@@ -123,28 +119,6 @@ func (o *GetPaymentCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment custom fields params
-func (o *GetPaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment custom fields params
-func (o *GetPaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment custom fields params
-func (o *GetPaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment custom fields params
-func (o *GetPaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get payment custom fields params
 func (o *GetPaymentCustomFieldsParams) WithAudit(audit *string) *GetPaymentCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetPaymentCustomFieldsParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment/get_payment_parameters.go
+++ b/kbclient/payment/get_payment_parameters.go
@@ -91,10 +91,6 @@ for the get payment operation typically these are written to a http.Request
 */
 type GetPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*PaymentID*/
@@ -144,28 +140,6 @@ func (o *GetPaymentParams) WithHTTPClient(client *http.Client) *GetPaymentParams
 // SetHTTPClient adds the HTTPClient to the get payment params
 func (o *GetPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment params
-func (o *GetPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment params
-func (o *GetPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment params
-func (o *GetPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment params
-func (o *GetPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payment params
@@ -230,16 +204,6 @@ func (o *GetPaymentParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment/get_payment_tags_parameters.go
+++ b/kbclient/payment/get_payment_tags_parameters.go
@@ -83,10 +83,6 @@ for the get payment tags operation typically these are written to a http.Request
 */
 type GetPaymentTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*IncludedDeleted*/
@@ -134,28 +130,6 @@ func (o *GetPaymentTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment tags params
-func (o *GetPaymentTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment tags params
-func (o *GetPaymentTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment tags params
-func (o *GetPaymentTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment tags params
-func (o *GetPaymentTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get payment tags params
 func (o *GetPaymentTagsParams) WithAudit(audit *string) *GetPaymentTagsParams {
 	o.SetAudit(audit)
@@ -196,16 +170,6 @@ func (o *GetPaymentTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment/get_payments_parameters.go
+++ b/kbclient/payment/get_payments_parameters.go
@@ -107,10 +107,6 @@ for the get payments operation typically these are written to a http.Request
 */
 type GetPaymentsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -164,28 +160,6 @@ func (o *GetPaymentsParams) WithHTTPClient(client *http.Client) *GetPaymentsPara
 // SetHTTPClient adds the HTTPClient to the get payments params
 func (o *GetPaymentsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payments params
-func (o *GetPaymentsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payments params
-func (o *GetPaymentsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payments params
-func (o *GetPaymentsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payments params
-func (o *GetPaymentsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payments params
@@ -272,16 +246,6 @@ func (o *GetPaymentsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment/modify_payment_custom_fields_parameters.go
+++ b/kbclient/payment/modify_payment_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify payment custom fields operation typically these are written to a 
 */
 type ModifyPaymentCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyPaymentCustomFieldsParams) WithHTTPClient(client *http.Client) *M
 // SetHTTPClient adds the HTTPClient to the modify payment custom fields params
 func (o *ModifyPaymentCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify payment custom fields params
-func (o *ModifyPaymentCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyPaymentCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify payment custom fields params
-func (o *ModifyPaymentCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify payment custom fields params
-func (o *ModifyPaymentCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyPaymentCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify payment custom fields params
-func (o *ModifyPaymentCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify payment custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyPaymentCustomFieldsParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/payment_client.go
+++ b/kbclient/payment/payment_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -202,14 +198,6 @@ func (a *Client) CancelScheduledPaymentTransactionByExternalKey(ctx context.Cont
 		params = NewCancelScheduledPaymentTransactionByExternalKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -255,14 +243,6 @@ func (a *Client) CancelScheduledPaymentTransactionByID(ctx context.Context, para
 		params = NewCancelScheduledPaymentTransactionByIDParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -310,31 +290,18 @@ func (a *Client) CaptureAuthorization(ctx context.Context, params *CaptureAuthor
 	getParams := NewCaptureAuthorizationParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -393,31 +360,18 @@ func (a *Client) CaptureAuthorizationByExternalKey(ctx context.Context, params *
 	getParams := NewCaptureAuthorizationByExternalKeyParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -476,31 +430,18 @@ func (a *Client) ChargebackPayment(ctx context.Context, params *ChargebackPaymen
 	getParams := NewChargebackPaymentParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -559,31 +500,18 @@ func (a *Client) ChargebackPaymentByExternalKey(ctx context.Context, params *Cha
 	getParams := NewChargebackPaymentByExternalKeyParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -642,31 +570,18 @@ func (a *Client) ChargebackReversalPayment(ctx context.Context, params *Chargeba
 	getParams := NewChargebackReversalPaymentParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -725,31 +640,18 @@ func (a *Client) ChargebackReversalPaymentByExternalKey(ctx context.Context, par
 	getParams := NewChargebackReversalPaymentByExternalKeyParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -806,14 +708,6 @@ func (a *Client) CompleteTransaction(ctx context.Context, params *CompleteTransa
 		params = NewCompleteTransactionParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -859,14 +753,6 @@ func (a *Client) CompleteTransactionByExternalKey(ctx context.Context, params *C
 		params = NewCompleteTransactionByExternalKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -914,31 +800,18 @@ func (a *Client) CreateComboPayment(ctx context.Context, params *CreateComboPaym
 	getParams := NewCreateComboPaymentParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -997,31 +870,18 @@ func (a *Client) CreatePaymentCustomFields(ctx context.Context, params *CreatePa
 	getParams := NewCreatePaymentCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1080,31 +940,18 @@ func (a *Client) CreatePaymentTags(ctx context.Context, params *CreatePaymentTag
 	getParams := NewCreatePaymentTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1161,14 +1008,6 @@ func (a *Client) DeletePaymentCustomFields(ctx context.Context, params *DeletePa
 		params = NewDeletePaymentCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1214,14 +1053,6 @@ func (a *Client) DeletePaymentTags(ctx context.Context, params *DeletePaymentTag
 		params = NewDeletePaymentTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1267,14 +1098,6 @@ func (a *Client) GetPayment(ctx context.Context, params *GetPaymentParams) (*Get
 		params = NewGetPaymentParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1308,14 +1131,6 @@ func (a *Client) GetPaymentAttemptAuditLogsWithHistory(ctx context.Context, para
 		params = NewGetPaymentAttemptAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1349,14 +1164,6 @@ func (a *Client) GetPaymentAuditLogsWithHistory(ctx context.Context, params *Get
 		params = NewGetPaymentAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1390,14 +1197,6 @@ func (a *Client) GetPaymentByExternalKey(ctx context.Context, params *GetPayment
 		params = NewGetPaymentByExternalKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1431,14 +1230,6 @@ func (a *Client) GetPaymentCustomFields(ctx context.Context, params *GetPaymentC
 		params = NewGetPaymentCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1472,14 +1263,6 @@ func (a *Client) GetPaymentTags(ctx context.Context, params *GetPaymentTagsParam
 		params = NewGetPaymentTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1513,14 +1296,6 @@ func (a *Client) GetPayments(ctx context.Context, params *GetPaymentsParams) (*G
 		params = NewGetPaymentsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1554,14 +1329,6 @@ func (a *Client) ModifyPaymentCustomFields(ctx context.Context, params *ModifyPa
 		params = NewModifyPaymentCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1609,31 +1376,18 @@ func (a *Client) RefundPayment(ctx context.Context, params *RefundPaymentParams)
 	getParams := NewRefundPaymentParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1692,31 +1446,18 @@ func (a *Client) RefundPaymentByExternalKey(ctx context.Context, params *RefundP
 	getParams := NewRefundPaymentByExternalKeyParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1773,14 +1514,6 @@ func (a *Client) SearchPayments(ctx context.Context, params *SearchPaymentsParam
 		params = NewSearchPaymentsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1814,14 +1547,6 @@ func (a *Client) VoidPayment(ctx context.Context, params *VoidPaymentParams) (*V
 		params = NewVoidPaymentParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1867,14 +1592,6 @@ func (a *Client) VoidPaymentByExternalKey(ctx context.Context, params *VoidPayme
 		params = NewVoidPaymentByExternalKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/payment/refund_payment_by_external_key_parameters.go
+++ b/kbclient/payment/refund_payment_by_external_key_parameters.go
@@ -65,10 +65,6 @@ for the refund payment by external key operation typically these are written to 
 */
 type RefundPaymentByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *RefundPaymentByExternalKeyParams) WithHTTPClient(client *http.Client) *
 // SetHTTPClient adds the HTTPClient to the refund payment by external key params
 func (o *RefundPaymentByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the refund payment by external key params
-func (o *RefundPaymentByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RefundPaymentByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the refund payment by external key params
-func (o *RefundPaymentByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the refund payment by external key params
-func (o *RefundPaymentByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RefundPaymentByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the refund payment by external key params
-func (o *RefundPaymentByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the refund payment by external key params
@@ -217,16 +191,6 @@ func (o *RefundPaymentByExternalKeyParams) WriteToRequest(r runtime.ClientReques
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/refund_payment_parameters.go
+++ b/kbclient/payment/refund_payment_parameters.go
@@ -65,10 +65,6 @@ for the refund payment operation typically these are written to a http.Request
 */
 type RefundPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *RefundPaymentParams) WithHTTPClient(client *http.Client) *RefundPayment
 // SetHTTPClient adds the HTTPClient to the refund payment params
 func (o *RefundPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the refund payment params
-func (o *RefundPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RefundPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the refund payment params
-func (o *RefundPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the refund payment params
-func (o *RefundPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RefundPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the refund payment params
-func (o *RefundPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the refund payment params
@@ -230,16 +204,6 @@ func (o *RefundPaymentParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/search_payments_parameters.go
+++ b/kbclient/payment/search_payments_parameters.go
@@ -107,10 +107,6 @@ for the search payments operation typically these are written to a http.Request
 */
 type SearchPaymentsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -166,28 +162,6 @@ func (o *SearchPaymentsParams) WithHTTPClient(client *http.Client) *SearchPaymen
 // SetHTTPClient adds the HTTPClient to the search payments params
 func (o *SearchPaymentsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the search payments params
-func (o *SearchPaymentsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SearchPaymentsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the search payments params
-func (o *SearchPaymentsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the search payments params
-func (o *SearchPaymentsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SearchPaymentsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the search payments params
-func (o *SearchPaymentsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the search payments params
@@ -285,16 +259,6 @@ func (o *SearchPaymentsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment/void_payment_by_external_key_parameters.go
+++ b/kbclient/payment/void_payment_by_external_key_parameters.go
@@ -65,10 +65,6 @@ for the void payment by external key operation typically these are written to a 
 */
 type VoidPaymentByExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *VoidPaymentByExternalKeyParams) WithHTTPClient(client *http.Client) *Vo
 // SetHTTPClient adds the HTTPClient to the void payment by external key params
 func (o *VoidPaymentByExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the void payment by external key params
-func (o *VoidPaymentByExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *VoidPaymentByExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the void payment by external key params
-func (o *VoidPaymentByExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the void payment by external key params
-func (o *VoidPaymentByExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *VoidPaymentByExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the void payment by external key params
-func (o *VoidPaymentByExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the void payment by external key params
@@ -217,16 +191,6 @@ func (o *VoidPaymentByExternalKeyParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment/void_payment_parameters.go
+++ b/kbclient/payment/void_payment_parameters.go
@@ -65,10 +65,6 @@ for the void payment operation typically these are written to a http.Request
 */
 type VoidPaymentParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *VoidPaymentParams) WithHTTPClient(client *http.Client) *VoidPaymentPara
 // SetHTTPClient adds the HTTPClient to the void payment params
 func (o *VoidPaymentParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the void payment params
-func (o *VoidPaymentParams) WithXKillbillAPIKey(xKillbillAPIKey string) *VoidPaymentParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the void payment params
-func (o *VoidPaymentParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the void payment params
-func (o *VoidPaymentParams) WithXKillbillAPISecret(xKillbillAPISecret string) *VoidPaymentParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the void payment params
-func (o *VoidPaymentParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the void payment params
@@ -230,16 +204,6 @@ func (o *VoidPaymentParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_gateway/build_combo_form_descriptor_parameters.go
+++ b/kbclient/payment_gateway/build_combo_form_descriptor_parameters.go
@@ -65,10 +65,6 @@ for the build combo form descriptor operation typically these are written to a h
 */
 type BuildComboFormDescriptorParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *BuildComboFormDescriptorParams) WithHTTPClient(client *http.Client) *Bu
 // SetHTTPClient adds the HTTPClient to the build combo form descriptor params
 func (o *BuildComboFormDescriptorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the build combo form descriptor params
-func (o *BuildComboFormDescriptorParams) WithXKillbillAPIKey(xKillbillAPIKey string) *BuildComboFormDescriptorParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the build combo form descriptor params
-func (o *BuildComboFormDescriptorParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the build combo form descriptor params
-func (o *BuildComboFormDescriptorParams) WithXKillbillAPISecret(xKillbillAPISecret string) *BuildComboFormDescriptorParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the build combo form descriptor params
-func (o *BuildComboFormDescriptorParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the build combo form descriptor params
@@ -217,16 +191,6 @@ func (o *BuildComboFormDescriptorParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_gateway/build_form_descriptor_parameters.go
+++ b/kbclient/payment_gateway/build_form_descriptor_parameters.go
@@ -65,10 +65,6 @@ for the build form descriptor operation typically these are written to a http.Re
 */
 type BuildFormDescriptorParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -124,28 +120,6 @@ func (o *BuildFormDescriptorParams) WithHTTPClient(client *http.Client) *BuildFo
 // SetHTTPClient adds the HTTPClient to the build form descriptor params
 func (o *BuildFormDescriptorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the build form descriptor params
-func (o *BuildFormDescriptorParams) WithXKillbillAPIKey(xKillbillAPIKey string) *BuildFormDescriptorParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the build form descriptor params
-func (o *BuildFormDescriptorParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the build form descriptor params
-func (o *BuildFormDescriptorParams) WithXKillbillAPISecret(xKillbillAPISecret string) *BuildFormDescriptorParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the build form descriptor params
-func (o *BuildFormDescriptorParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the build form descriptor params
@@ -243,16 +217,6 @@ func (o *BuildFormDescriptorParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_gateway/payment_gateway_client.go
+++ b/kbclient/payment_gateway/payment_gateway_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -78,14 +74,6 @@ func (a *Client) BuildComboFormDescriptor(ctx context.Context, params *BuildComb
 		params = NewBuildComboFormDescriptorParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -131,14 +119,6 @@ func (a *Client) BuildFormDescriptor(ctx context.Context, params *BuildFormDescr
 		params = NewBuildFormDescriptorParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -186,14 +166,6 @@ func (a *Client) ProcessNotification(ctx context.Context, params *ProcessNotific
 		params = NewProcessNotificationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/payment_gateway/process_notification_parameters.go
+++ b/kbclient/payment_gateway/process_notification_parameters.go
@@ -63,10 +63,6 @@ for the process notification operation typically these are written to a http.Req
 */
 type ProcessNotificationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *ProcessNotificationParams) WithHTTPClient(client *http.Client) *Process
 // SetHTTPClient adds the HTTPClient to the process notification params
 func (o *ProcessNotificationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the process notification params
-func (o *ProcessNotificationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ProcessNotificationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the process notification params
-func (o *ProcessNotificationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the process notification params
-func (o *ProcessNotificationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ProcessNotificationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the process notification params
-func (o *ProcessNotificationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the process notification params
@@ -228,16 +202,6 @@ func (o *ProcessNotificationParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_method/create_payment_method_custom_fields_parameters.go
+++ b/kbclient/payment_method/create_payment_method_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create payment method custom fields operation typically these are writte
 */
 type CreatePaymentMethodCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreatePaymentMethodCustomFieldsParams) WithHTTPClient(client *http.Clie
 // SetHTTPClient adds the HTTPClient to the create payment method custom fields params
 func (o *CreatePaymentMethodCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create payment method custom fields params
-func (o *CreatePaymentMethodCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreatePaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create payment method custom fields params
-func (o *CreatePaymentMethodCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create payment method custom fields params
-func (o *CreatePaymentMethodCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreatePaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create payment method custom fields params
-func (o *CreatePaymentMethodCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create payment method custom fields params
@@ -203,16 +177,6 @@ func (o *CreatePaymentMethodCustomFieldsParams) WriteToRequest(r runtime.ClientR
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_method/delete_payment_method_custom_fields_parameters.go
+++ b/kbclient/payment_method/delete_payment_method_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete payment method custom fields operation typically these are writte
 */
 type DeletePaymentMethodCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeletePaymentMethodCustomFieldsParams) WithHTTPClient(client *http.Clie
 // SetHTTPClient adds the HTTPClient to the delete payment method custom fields params
 func (o *DeletePaymentMethodCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete payment method custom fields params
-func (o *DeletePaymentMethodCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete payment method custom fields params
-func (o *DeletePaymentMethodCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete payment method custom fields params
-func (o *DeletePaymentMethodCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete payment method custom fields params
-func (o *DeletePaymentMethodCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete payment method custom fields params
@@ -202,16 +176,6 @@ func (o *DeletePaymentMethodCustomFieldsParams) WriteToRequest(r runtime.ClientR
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_method/delete_payment_method_parameters.go
+++ b/kbclient/payment_method/delete_payment_method_parameters.go
@@ -83,10 +83,6 @@ for the delete payment method operation typically these are written to a http.Re
 */
 type DeletePaymentMethodParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -140,28 +136,6 @@ func (o *DeletePaymentMethodParams) WithHTTPClient(client *http.Client) *DeleteP
 // SetHTTPClient adds the HTTPClient to the delete payment method params
 func (o *DeletePaymentMethodParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete payment method params
-func (o *DeletePaymentMethodParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePaymentMethodParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete payment method params
-func (o *DeletePaymentMethodParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete payment method params
-func (o *DeletePaymentMethodParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePaymentMethodParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete payment method params
-func (o *DeletePaymentMethodParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete payment method params
@@ -248,16 +222,6 @@ func (o *DeletePaymentMethodParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_method/get_payment_method_audit_logs_with_history_parameters.go
+++ b/kbclient/payment_method/get_payment_method_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get payment method audit logs with history operation typically these are
 */
 type GetPaymentMethodAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*PaymentMethodID*/
 	PaymentMethodID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetPaymentMethodAuditLogsWithHistoryParams) SetHTTPClient(client *http.
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment method audit logs with history params
-func (o *GetPaymentMethodAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentMethodAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment method audit logs with history params
-func (o *GetPaymentMethodAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment method audit logs with history params
-func (o *GetPaymentMethodAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentMethodAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment method audit logs with history params
-func (o *GetPaymentMethodAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithPaymentMethodID adds the paymentMethodID to the get payment method audit logs with history params
 func (o *GetPaymentMethodAuditLogsWithHistoryParams) WithPaymentMethodID(paymentMethodID strfmt.UUID) *GetPaymentMethodAuditLogsWithHistoryParams {
 	o.SetPaymentMethodID(paymentMethodID)
@@ -149,16 +123,6 @@ func (o *GetPaymentMethodAuditLogsWithHistoryParams) WriteToRequest(r runtime.Cl
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param paymentMethodId
 	if err := r.SetPathParam("paymentMethodId", o.PaymentMethodID.String()); err != nil {

--- a/kbclient/payment_method/get_payment_method_by_key_parameters.go
+++ b/kbclient/payment_method/get_payment_method_by_key_parameters.go
@@ -91,10 +91,6 @@ for the get payment method by key operation typically these are written to a htt
 */
 type GetPaymentMethodByKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*ExternalKey*/
@@ -144,28 +140,6 @@ func (o *GetPaymentMethodByKeyParams) WithHTTPClient(client *http.Client) *GetPa
 // SetHTTPClient adds the HTTPClient to the get payment method by key params
 func (o *GetPaymentMethodByKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment method by key params
-func (o *GetPaymentMethodByKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentMethodByKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment method by key params
-func (o *GetPaymentMethodByKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment method by key params
-func (o *GetPaymentMethodByKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentMethodByKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment method by key params
-func (o *GetPaymentMethodByKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payment method by key params
@@ -230,16 +204,6 @@ func (o *GetPaymentMethodByKeyParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_method/get_payment_method_custom_fields_parameters.go
+++ b/kbclient/payment_method/get_payment_method_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get payment method custom fields operation typically these are written t
 */
 type GetPaymentMethodCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*PaymentMethodID*/
@@ -123,28 +119,6 @@ func (o *GetPaymentMethodCustomFieldsParams) SetHTTPClient(client *http.Client) 
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment method custom fields params
-func (o *GetPaymentMethodCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment method custom fields params
-func (o *GetPaymentMethodCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment method custom fields params
-func (o *GetPaymentMethodCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment method custom fields params
-func (o *GetPaymentMethodCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get payment method custom fields params
 func (o *GetPaymentMethodCustomFieldsParams) WithAudit(audit *string) *GetPaymentMethodCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetPaymentMethodCustomFieldsParams) WriteToRequest(r runtime.ClientRequ
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_method/get_payment_method_parameters.go
+++ b/kbclient/payment_method/get_payment_method_parameters.go
@@ -91,10 +91,6 @@ for the get payment method operation typically these are written to a http.Reque
 */
 type GetPaymentMethodParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*IncludedDeleted*/
@@ -144,28 +140,6 @@ func (o *GetPaymentMethodParams) WithHTTPClient(client *http.Client) *GetPayment
 // SetHTTPClient adds the HTTPClient to the get payment method params
 func (o *GetPaymentMethodParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment method params
-func (o *GetPaymentMethodParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentMethodParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment method params
-func (o *GetPaymentMethodParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment method params
-func (o *GetPaymentMethodParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentMethodParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment method params
-func (o *GetPaymentMethodParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payment method params
@@ -230,16 +204,6 @@ func (o *GetPaymentMethodParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_method/get_payment_methods_parameters.go
+++ b/kbclient/payment_method/get_payment_methods_parameters.go
@@ -99,10 +99,6 @@ for the get payment methods operation typically these are written to a http.Requ
 */
 type GetPaymentMethodsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -154,28 +150,6 @@ func (o *GetPaymentMethodsParams) WithHTTPClient(client *http.Client) *GetPaymen
 // SetHTTPClient adds the HTTPClient to the get payment methods params
 func (o *GetPaymentMethodsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment methods params
-func (o *GetPaymentMethodsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentMethodsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment methods params
-func (o *GetPaymentMethodsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment methods params
-func (o *GetPaymentMethodsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentMethodsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment methods params
-func (o *GetPaymentMethodsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payment methods params
@@ -251,16 +225,6 @@ func (o *GetPaymentMethodsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_method/modify_payment_method_custom_fields_parameters.go
+++ b/kbclient/payment_method/modify_payment_method_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify payment method custom fields operation typically these are writte
 */
 type ModifyPaymentMethodCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyPaymentMethodCustomFieldsParams) WithHTTPClient(client *http.Clie
 // SetHTTPClient adds the HTTPClient to the modify payment method custom fields params
 func (o *ModifyPaymentMethodCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify payment method custom fields params
-func (o *ModifyPaymentMethodCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyPaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify payment method custom fields params
-func (o *ModifyPaymentMethodCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify payment method custom fields params
-func (o *ModifyPaymentMethodCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyPaymentMethodCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify payment method custom fields params
-func (o *ModifyPaymentMethodCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify payment method custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyPaymentMethodCustomFieldsParams) WriteToRequest(r runtime.ClientR
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_method/payment_method_client.go
+++ b/kbclient/payment_method/payment_method_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -114,31 +110,18 @@ func (a *Client) CreatePaymentMethodCustomFields(ctx context.Context, params *Cr
 	getParams := NewCreatePaymentMethodCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -195,14 +178,6 @@ func (a *Client) DeletePaymentMethod(ctx context.Context, params *DeletePaymentM
 		params = NewDeletePaymentMethodParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -248,14 +223,6 @@ func (a *Client) DeletePaymentMethodCustomFields(ctx context.Context, params *De
 		params = NewDeletePaymentMethodCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -301,14 +268,6 @@ func (a *Client) GetPaymentMethod(ctx context.Context, params *GetPaymentMethodP
 		params = NewGetPaymentMethodParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -342,14 +301,6 @@ func (a *Client) GetPaymentMethodAuditLogsWithHistory(ctx context.Context, param
 		params = NewGetPaymentMethodAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -383,14 +334,6 @@ func (a *Client) GetPaymentMethodByKey(ctx context.Context, params *GetPaymentMe
 		params = NewGetPaymentMethodByKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -424,14 +367,6 @@ func (a *Client) GetPaymentMethodCustomFields(ctx context.Context, params *GetPa
 		params = NewGetPaymentMethodCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -465,14 +400,6 @@ func (a *Client) GetPaymentMethods(ctx context.Context, params *GetPaymentMethod
 		params = NewGetPaymentMethodsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -506,14 +433,6 @@ func (a *Client) ModifyPaymentMethodCustomFields(ctx context.Context, params *Mo
 		params = NewModifyPaymentMethodCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -559,14 +478,6 @@ func (a *Client) SearchPaymentMethods(ctx context.Context, params *SearchPayment
 		params = NewSearchPaymentMethodsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/payment_method/search_payment_methods_parameters.go
+++ b/kbclient/payment_method/search_payment_methods_parameters.go
@@ -99,10 +99,6 @@ for the search payment methods operation typically these are written to a http.R
 */
 type SearchPaymentMethodsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -156,28 +152,6 @@ func (o *SearchPaymentMethodsParams) WithHTTPClient(client *http.Client) *Search
 // SetHTTPClient adds the HTTPClient to the search payment methods params
 func (o *SearchPaymentMethodsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the search payment methods params
-func (o *SearchPaymentMethodsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SearchPaymentMethodsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the search payment methods params
-func (o *SearchPaymentMethodsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the search payment methods params
-func (o *SearchPaymentMethodsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SearchPaymentMethodsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the search payment methods params
-func (o *SearchPaymentMethodsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the search payment methods params
@@ -264,16 +238,6 @@ func (o *SearchPaymentMethodsParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_transaction/create_transaction_custom_fields_parameters.go
+++ b/kbclient/payment_transaction/create_transaction_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create transaction custom fields operation typically these are written t
 */
 type CreateTransactionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreateTransactionCustomFieldsParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the create transaction custom fields params
 func (o *CreateTransactionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create transaction custom fields params
-func (o *CreateTransactionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateTransactionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create transaction custom fields params
-func (o *CreateTransactionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create transaction custom fields params
-func (o *CreateTransactionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateTransactionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create transaction custom fields params
-func (o *CreateTransactionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create transaction custom fields params
@@ -203,16 +177,6 @@ func (o *CreateTransactionCustomFieldsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_transaction/create_transaction_tags_parameters.go
+++ b/kbclient/payment_transaction/create_transaction_tags_parameters.go
@@ -62,10 +62,6 @@ for the create transaction tags operation typically these are written to a http.
 */
 type CreateTransactionTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateTransactionTagsParams) WithHTTPClient(client *http.Client) *Creat
 // SetHTTPClient adds the HTTPClient to the create transaction tags params
 func (o *CreateTransactionTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create transaction tags params
-func (o *CreateTransactionTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateTransactionTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create transaction tags params
-func (o *CreateTransactionTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create transaction tags params
-func (o *CreateTransactionTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateTransactionTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create transaction tags params
-func (o *CreateTransactionTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create transaction tags params
@@ -201,16 +175,6 @@ func (o *CreateTransactionTagsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_transaction/delete_transaction_custom_fields_parameters.go
+++ b/kbclient/payment_transaction/delete_transaction_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete transaction custom fields operation typically these are written t
 */
 type DeleteTransactionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteTransactionCustomFieldsParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the delete transaction custom fields params
 func (o *DeleteTransactionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete transaction custom fields params
-func (o *DeleteTransactionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteTransactionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete transaction custom fields params
-func (o *DeleteTransactionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete transaction custom fields params
-func (o *DeleteTransactionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteTransactionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete transaction custom fields params
-func (o *DeleteTransactionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete transaction custom fields params
@@ -202,16 +176,6 @@ func (o *DeleteTransactionCustomFieldsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_transaction/delete_transaction_tags_parameters.go
+++ b/kbclient/payment_transaction/delete_transaction_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete transaction tags operation typically these are written to a http.
 */
 type DeleteTransactionTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteTransactionTagsParams) WithHTTPClient(client *http.Client) *Delet
 // SetHTTPClient adds the HTTPClient to the delete transaction tags params
 func (o *DeleteTransactionTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete transaction tags params
-func (o *DeleteTransactionTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteTransactionTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete transaction tags params
-func (o *DeleteTransactionTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete transaction tags params
-func (o *DeleteTransactionTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteTransactionTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete transaction tags params
-func (o *DeleteTransactionTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete transaction tags params
@@ -202,16 +176,6 @@ func (o *DeleteTransactionTagsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_transaction/get_payment_by_transaction_external_key_parameters.go
+++ b/kbclient/payment_transaction/get_payment_by_transaction_external_key_parameters.go
@@ -91,10 +91,6 @@ for the get payment by transaction external key operation typically these are wr
 */
 type GetPaymentByTransactionExternalKeyParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*PluginProperty*/
@@ -144,28 +140,6 @@ func (o *GetPaymentByTransactionExternalKeyParams) WithHTTPClient(client *http.C
 // SetHTTPClient adds the HTTPClient to the get payment by transaction external key params
 func (o *GetPaymentByTransactionExternalKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment by transaction external key params
-func (o *GetPaymentByTransactionExternalKeyParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentByTransactionExternalKeyParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment by transaction external key params
-func (o *GetPaymentByTransactionExternalKeyParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment by transaction external key params
-func (o *GetPaymentByTransactionExternalKeyParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentByTransactionExternalKeyParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment by transaction external key params
-func (o *GetPaymentByTransactionExternalKeyParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payment by transaction external key params
@@ -230,16 +204,6 @@ func (o *GetPaymentByTransactionExternalKeyParams) WriteToRequest(r runtime.Clie
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_transaction/get_payment_by_transaction_id_parameters.go
+++ b/kbclient/payment_transaction/get_payment_by_transaction_id_parameters.go
@@ -91,10 +91,6 @@ for the get payment by transaction Id operation typically these are written to a
 */
 type GetPaymentByTransactionIDParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*PluginProperty*/
@@ -144,28 +140,6 @@ func (o *GetPaymentByTransactionIDParams) WithHTTPClient(client *http.Client) *G
 // SetHTTPClient adds the HTTPClient to the get payment by transaction Id params
 func (o *GetPaymentByTransactionIDParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get payment by transaction Id params
-func (o *GetPaymentByTransactionIDParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPaymentByTransactionIDParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get payment by transaction Id params
-func (o *GetPaymentByTransactionIDParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get payment by transaction Id params
-func (o *GetPaymentByTransactionIDParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPaymentByTransactionIDParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get payment by transaction Id params
-func (o *GetPaymentByTransactionIDParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the get payment by transaction Id params
@@ -230,16 +204,6 @@ func (o *GetPaymentByTransactionIDParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_transaction/get_transaction_audit_logs_with_history_parameters.go
+++ b/kbclient/payment_transaction/get_transaction_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get transaction audit logs with history operation typically these are wr
 */
 type GetTransactionAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*TransactionID*/
 	TransactionID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetTransactionAuditLogsWithHistoryParams) SetHTTPClient(client *http.Cl
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get transaction audit logs with history params
-func (o *GetTransactionAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTransactionAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get transaction audit logs with history params
-func (o *GetTransactionAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get transaction audit logs with history params
-func (o *GetTransactionAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTransactionAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get transaction audit logs with history params
-func (o *GetTransactionAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithTransactionID adds the transactionID to the get transaction audit logs with history params
 func (o *GetTransactionAuditLogsWithHistoryParams) WithTransactionID(transactionID strfmt.UUID) *GetTransactionAuditLogsWithHistoryParams {
 	o.SetTransactionID(transactionID)
@@ -149,16 +123,6 @@ func (o *GetTransactionAuditLogsWithHistoryParams) WriteToRequest(r runtime.Clie
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param transactionId
 	if err := r.SetPathParam("transactionId", o.TransactionID.String()); err != nil {

--- a/kbclient/payment_transaction/get_transaction_custom_fields_parameters.go
+++ b/kbclient/payment_transaction/get_transaction_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get transaction custom fields operation typically these are written to a
 */
 type GetTransactionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*TransactionID*/
@@ -123,28 +119,6 @@ func (o *GetTransactionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get transaction custom fields params
-func (o *GetTransactionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTransactionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get transaction custom fields params
-func (o *GetTransactionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get transaction custom fields params
-func (o *GetTransactionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTransactionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get transaction custom fields params
-func (o *GetTransactionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get transaction custom fields params
 func (o *GetTransactionCustomFieldsParams) WithAudit(audit *string) *GetTransactionCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetTransactionCustomFieldsParams) WriteToRequest(r runtime.ClientReques
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_transaction/get_transaction_tags_parameters.go
+++ b/kbclient/payment_transaction/get_transaction_tags_parameters.go
@@ -83,10 +83,6 @@ for the get transaction tags operation typically these are written to a http.Req
 */
 type GetTransactionTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*IncludedDeleted*/
@@ -134,28 +130,6 @@ func (o *GetTransactionTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get transaction tags params
-func (o *GetTransactionTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTransactionTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get transaction tags params
-func (o *GetTransactionTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get transaction tags params
-func (o *GetTransactionTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTransactionTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get transaction tags params
-func (o *GetTransactionTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get transaction tags params
 func (o *GetTransactionTagsParams) WithAudit(audit *string) *GetTransactionTagsParams {
 	o.SetAudit(audit)
@@ -196,16 +170,6 @@ func (o *GetTransactionTagsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/payment_transaction/modify_transaction_custom_fields_parameters.go
+++ b/kbclient/payment_transaction/modify_transaction_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify transaction custom fields operation typically these are written t
 */
 type ModifyTransactionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifyTransactionCustomFieldsParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the modify transaction custom fields params
 func (o *ModifyTransactionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify transaction custom fields params
-func (o *ModifyTransactionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifyTransactionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify transaction custom fields params
-func (o *ModifyTransactionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify transaction custom fields params
-func (o *ModifyTransactionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifyTransactionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify transaction custom fields params
-func (o *ModifyTransactionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify transaction custom fields params
@@ -203,16 +177,6 @@ func (o *ModifyTransactionCustomFieldsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_transaction/notify_state_changed_parameters.go
+++ b/kbclient/payment_transaction/notify_state_changed_parameters.go
@@ -65,10 +65,6 @@ for the notify state changed operation typically these are written to a http.Req
 */
 type NotifyStateChangedParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -120,28 +116,6 @@ func (o *NotifyStateChangedParams) WithHTTPClient(client *http.Client) *NotifySt
 // SetHTTPClient adds the HTTPClient to the notify state changed params
 func (o *NotifyStateChangedParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the notify state changed params
-func (o *NotifyStateChangedParams) WithXKillbillAPIKey(xKillbillAPIKey string) *NotifyStateChangedParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the notify state changed params
-func (o *NotifyStateChangedParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the notify state changed params
-func (o *NotifyStateChangedParams) WithXKillbillAPISecret(xKillbillAPISecret string) *NotifyStateChangedParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the notify state changed params
-func (o *NotifyStateChangedParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the notify state changed params
@@ -217,16 +191,6 @@ func (o *NotifyStateChangedParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/payment_transaction/payment_transaction_client.go
+++ b/kbclient/payment_transaction/payment_transaction_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -119,31 +115,18 @@ func (a *Client) CreateTransactionCustomFields(ctx context.Context, params *Crea
 	getParams := NewCreateTransactionCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -202,31 +185,18 @@ func (a *Client) CreateTransactionTags(ctx context.Context, params *CreateTransa
 	getParams := NewCreateTransactionTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -283,14 +253,6 @@ func (a *Client) DeleteTransactionCustomFields(ctx context.Context, params *Dele
 		params = NewDeleteTransactionCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -336,14 +298,6 @@ func (a *Client) DeleteTransactionTags(ctx context.Context, params *DeleteTransa
 		params = NewDeleteTransactionTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -389,14 +343,6 @@ func (a *Client) GetPaymentByTransactionExternalKey(ctx context.Context, params 
 		params = NewGetPaymentByTransactionExternalKeyParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -430,14 +376,6 @@ func (a *Client) GetPaymentByTransactionID(ctx context.Context, params *GetPayme
 		params = NewGetPaymentByTransactionIDParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -471,14 +409,6 @@ func (a *Client) GetTransactionAuditLogsWithHistory(ctx context.Context, params 
 		params = NewGetTransactionAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -512,14 +442,6 @@ func (a *Client) GetTransactionCustomFields(ctx context.Context, params *GetTran
 		params = NewGetTransactionCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -553,14 +475,6 @@ func (a *Client) GetTransactionTags(ctx context.Context, params *GetTransactionT
 		params = NewGetTransactionTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -594,14 +508,6 @@ func (a *Client) ModifyTransactionCustomFields(ctx context.Context, params *Modi
 		params = NewModifyTransactionCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -649,31 +555,18 @@ func (a *Client) NotifyStateChanged(ctx context.Context, params *NotifyStateChan
 	getParams := NewNotifyStateChangedParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/plugin_info/get_plugins_info_parameters.go
+++ b/kbclient/plugin_info/get_plugins_info_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewGetPluginsInfoParams creates a new GetPluginsInfoParams object
 // with the default values initialized.
 func NewGetPluginsInfoParams() *GetPluginsInfoParams {
-	var ()
+
 	return &GetPluginsInfoParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewGetPluginsInfoParams() *GetPluginsInfoParams {
 // NewGetPluginsInfoParamsWithTimeout creates a new GetPluginsInfoParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetPluginsInfoParamsWithTimeout(timeout time.Duration) *GetPluginsInfoParams {
-	var ()
+
 	return &GetPluginsInfoParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewGetPluginsInfoParamsWithTimeout(timeout time.Duration) *GetPluginsInfoPa
 // NewGetPluginsInfoParamsWithContext creates a new GetPluginsInfoParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetPluginsInfoParamsWithContext(ctx context.Context) *GetPluginsInfoParams {
-	var ()
+
 	return &GetPluginsInfoParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewGetPluginsInfoParamsWithContext(ctx context.Context) *GetPluginsInfoPara
 // NewGetPluginsInfoParamsWithHTTPClient creates a new GetPluginsInfoParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetPluginsInfoParamsWithHTTPClient(client *http.Client) *GetPluginsInfoParams {
-	var ()
+
 	return &GetPluginsInfoParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewGetPluginsInfoParamsWithHTTPClient(client *http.Client) *GetPluginsInfoP
 for the get plugins info operation typically these are written to a http.Request
 */
 type GetPluginsInfoParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *GetPluginsInfoParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get plugins info params
-func (o *GetPluginsInfoParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPluginsInfoParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get plugins info params
-func (o *GetPluginsInfoParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get plugins info params
-func (o *GetPluginsInfoParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPluginsInfoParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get plugins info params
-func (o *GetPluginsInfoParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *GetPluginsInfoParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *GetPluginsInfoParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/plugin_info/plugin_info_client.go
+++ b/kbclient/plugin_info/plugin_info_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -66,14 +62,6 @@ func (a *Client) GetPluginsInfo(ctx context.Context, params *GetPluginsInfoParam
 		params = NewGetPluginsInfoParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/security/security_client.go
+++ b/kbclient/security/security_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -114,22 +110,18 @@ func (a *Client) AddRoleDefinition(ctx context.Context, params *AddRoleDefinitio
 	getParams := NewAddRoleDefinitionParams()
 	getParams.Context = ctx
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -188,22 +180,18 @@ func (a *Client) AddUserRoles(ctx context.Context, params *AddUserRolesParams) (
 	getParams := NewAddUserRolesParams()
 	getParams.Context = ctx
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -326,7 +314,6 @@ func (a *Client) GetRoleDefinition(ctx context.Context, params *GetRoleDefinitio
 		params = NewGetRoleDefinitionParams()
 	}
 	params.Context = ctx
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -360,7 +347,6 @@ func (a *Client) GetUserRoles(ctx context.Context, params *GetUserRolesParams) (
 		params = NewGetUserRolesParams()
 	}
 	params.Context = ctx
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -394,7 +380,6 @@ func (a *Client) InvalidateUser(ctx context.Context, params *InvalidateUserParam
 		params = NewInvalidateUserParams()
 	}
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -440,7 +425,6 @@ func (a *Client) UpdateRoleDefinition(ctx context.Context, params *UpdateRoleDef
 		params = NewUpdateRoleDefinitionParams()
 	}
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -486,7 +470,6 @@ func (a *Client) UpdateUserPassword(ctx context.Context, params *UpdateUserPassw
 		params = NewUpdateUserPasswordParams()
 	}
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -532,7 +515,6 @@ func (a *Client) UpdateUserRoles(ctx context.Context, params *UpdateUserRolesPar
 		params = NewUpdateUserRolesParams()
 	}
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/subscription/add_subscription_blocking_state_parameters.go
+++ b/kbclient/subscription/add_subscription_blocking_state_parameters.go
@@ -65,10 +65,6 @@ for the add subscription blocking state operation typically these are written to
 */
 type AddSubscriptionBlockingStateParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -122,28 +118,6 @@ func (o *AddSubscriptionBlockingStateParams) WithHTTPClient(client *http.Client)
 // SetHTTPClient adds the HTTPClient to the add subscription blocking state params
 func (o *AddSubscriptionBlockingStateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the add subscription blocking state params
-func (o *AddSubscriptionBlockingStateParams) WithXKillbillAPIKey(xKillbillAPIKey string) *AddSubscriptionBlockingStateParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the add subscription blocking state params
-func (o *AddSubscriptionBlockingStateParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the add subscription blocking state params
-func (o *AddSubscriptionBlockingStateParams) WithXKillbillAPISecret(xKillbillAPISecret string) *AddSubscriptionBlockingStateParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the add subscription blocking state params
-func (o *AddSubscriptionBlockingStateParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the add subscription blocking state params
@@ -230,16 +204,6 @@ func (o *AddSubscriptionBlockingStateParams) WriteToRequest(r runtime.ClientRequ
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/cancel_subscription_plan_parameters.go
+++ b/kbclient/subscription/cancel_subscription_plan_parameters.go
@@ -91,10 +91,6 @@ for the cancel subscription plan operation typically these are written to a http
 */
 type CancelSubscriptionPlanParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -156,28 +152,6 @@ func (o *CancelSubscriptionPlanParams) WithHTTPClient(client *http.Client) *Canc
 // SetHTTPClient adds the HTTPClient to the cancel subscription plan params
 func (o *CancelSubscriptionPlanParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the cancel subscription plan params
-func (o *CancelSubscriptionPlanParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CancelSubscriptionPlanParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the cancel subscription plan params
-func (o *CancelSubscriptionPlanParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the cancel subscription plan params
-func (o *CancelSubscriptionPlanParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CancelSubscriptionPlanParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the cancel subscription plan params
-func (o *CancelSubscriptionPlanParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the cancel subscription plan params
@@ -308,16 +282,6 @@ func (o *CancelSubscriptionPlanParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/change_subscription_plan_parameters.go
+++ b/kbclient/subscription/change_subscription_plan_parameters.go
@@ -85,10 +85,6 @@ for the change subscription plan operation typically these are written to a http
 */
 type ChangeSubscriptionPlanParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -148,28 +144,6 @@ func (o *ChangeSubscriptionPlanParams) WithHTTPClient(client *http.Client) *Chan
 // SetHTTPClient adds the HTTPClient to the change subscription plan params
 func (o *ChangeSubscriptionPlanParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the change subscription plan params
-func (o *ChangeSubscriptionPlanParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ChangeSubscriptionPlanParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the change subscription plan params
-func (o *ChangeSubscriptionPlanParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the change subscription plan params
-func (o *ChangeSubscriptionPlanParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ChangeSubscriptionPlanParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the change subscription plan params
-func (o *ChangeSubscriptionPlanParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the change subscription plan params
@@ -289,16 +263,6 @@ func (o *ChangeSubscriptionPlanParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/create_subscription_custom_fields_parameters.go
+++ b/kbclient/subscription/create_subscription_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the create subscription custom fields operation typically these are written 
 */
 type CreateSubscriptionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *CreateSubscriptionCustomFieldsParams) WithHTTPClient(client *http.Clien
 // SetHTTPClient adds the HTTPClient to the create subscription custom fields params
 func (o *CreateSubscriptionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create subscription custom fields params
-func (o *CreateSubscriptionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateSubscriptionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create subscription custom fields params
-func (o *CreateSubscriptionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create subscription custom fields params
-func (o *CreateSubscriptionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateSubscriptionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create subscription custom fields params
-func (o *CreateSubscriptionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create subscription custom fields params
@@ -203,16 +177,6 @@ func (o *CreateSubscriptionCustomFieldsParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/create_subscription_parameters.go
+++ b/kbclient/subscription/create_subscription_parameters.go
@@ -101,10 +101,6 @@ for the create subscription operation typically these are written to a http.Requ
 */
 type CreateSubscriptionParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -168,28 +164,6 @@ func (o *CreateSubscriptionParams) WithHTTPClient(client *http.Client) *CreateSu
 // SetHTTPClient adds the HTTPClient to the create subscription params
 func (o *CreateSubscriptionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create subscription params
-func (o *CreateSubscriptionParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateSubscriptionParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create subscription params
-func (o *CreateSubscriptionParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create subscription params
-func (o *CreateSubscriptionParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateSubscriptionParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create subscription params
-func (o *CreateSubscriptionParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create subscription params
@@ -331,16 +305,6 @@ func (o *CreateSubscriptionParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/create_subscription_tags_parameters.go
+++ b/kbclient/subscription/create_subscription_tags_parameters.go
@@ -62,10 +62,6 @@ for the create subscription tags operation typically these are written to a http
 */
 type CreateSubscriptionTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateSubscriptionTagsParams) WithHTTPClient(client *http.Client) *Crea
 // SetHTTPClient adds the HTTPClient to the create subscription tags params
 func (o *CreateSubscriptionTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create subscription tags params
-func (o *CreateSubscriptionTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateSubscriptionTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create subscription tags params
-func (o *CreateSubscriptionTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create subscription tags params
-func (o *CreateSubscriptionTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateSubscriptionTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create subscription tags params
-func (o *CreateSubscriptionTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create subscription tags params
@@ -201,16 +175,6 @@ func (o *CreateSubscriptionTagsParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/create_subscription_with_add_ons_parameters.go
+++ b/kbclient/subscription/create_subscription_with_add_ons_parameters.go
@@ -101,10 +101,6 @@ for the create subscription with add ons operation typically these are written t
 */
 type CreateSubscriptionWithAddOnsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -166,28 +162,6 @@ func (o *CreateSubscriptionWithAddOnsParams) WithHTTPClient(client *http.Client)
 // SetHTTPClient adds the HTTPClient to the create subscription with add ons params
 func (o *CreateSubscriptionWithAddOnsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create subscription with add ons params
-func (o *CreateSubscriptionWithAddOnsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateSubscriptionWithAddOnsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create subscription with add ons params
-func (o *CreateSubscriptionWithAddOnsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create subscription with add ons params
-func (o *CreateSubscriptionWithAddOnsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateSubscriptionWithAddOnsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create subscription with add ons params
-func (o *CreateSubscriptionWithAddOnsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create subscription with add ons params
@@ -318,16 +292,6 @@ func (o *CreateSubscriptionWithAddOnsParams) WriteToRequest(r runtime.ClientRequ
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/create_subscriptions_with_add_ons_parameters.go
+++ b/kbclient/subscription/create_subscriptions_with_add_ons_parameters.go
@@ -101,10 +101,6 @@ for the create subscriptions with add ons operation typically these are written 
 */
 type CreateSubscriptionsWithAddOnsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -166,28 +162,6 @@ func (o *CreateSubscriptionsWithAddOnsParams) WithHTTPClient(client *http.Client
 // SetHTTPClient adds the HTTPClient to the create subscriptions with add ons params
 func (o *CreateSubscriptionsWithAddOnsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create subscriptions with add ons params
-func (o *CreateSubscriptionsWithAddOnsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateSubscriptionsWithAddOnsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create subscriptions with add ons params
-func (o *CreateSubscriptionsWithAddOnsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create subscriptions with add ons params
-func (o *CreateSubscriptionsWithAddOnsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateSubscriptionsWithAddOnsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create subscriptions with add ons params
-func (o *CreateSubscriptionsWithAddOnsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create subscriptions with add ons params
@@ -318,16 +292,6 @@ func (o *CreateSubscriptionsWithAddOnsParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/delete_subscription_custom_fields_parameters.go
+++ b/kbclient/subscription/delete_subscription_custom_fields_parameters.go
@@ -63,10 +63,6 @@ for the delete subscription custom fields operation typically these are written 
 */
 type DeleteSubscriptionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteSubscriptionCustomFieldsParams) WithHTTPClient(client *http.Clien
 // SetHTTPClient adds the HTTPClient to the delete subscription custom fields params
 func (o *DeleteSubscriptionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete subscription custom fields params
-func (o *DeleteSubscriptionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteSubscriptionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete subscription custom fields params
-func (o *DeleteSubscriptionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete subscription custom fields params
-func (o *DeleteSubscriptionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteSubscriptionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete subscription custom fields params
-func (o *DeleteSubscriptionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete subscription custom fields params
@@ -202,16 +176,6 @@ func (o *DeleteSubscriptionCustomFieldsParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/delete_subscription_tags_parameters.go
+++ b/kbclient/subscription/delete_subscription_tags_parameters.go
@@ -63,10 +63,6 @@ for the delete subscription tags operation typically these are written to a http
 */
 type DeleteSubscriptionTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *DeleteSubscriptionTagsParams) WithHTTPClient(client *http.Client) *Dele
 // SetHTTPClient adds the HTTPClient to the delete subscription tags params
 func (o *DeleteSubscriptionTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete subscription tags params
-func (o *DeleteSubscriptionTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteSubscriptionTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete subscription tags params
-func (o *DeleteSubscriptionTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete subscription tags params
-func (o *DeleteSubscriptionTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteSubscriptionTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete subscription tags params
-func (o *DeleteSubscriptionTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete subscription tags params
@@ -202,16 +176,6 @@ func (o *DeleteSubscriptionTagsParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/get_subscription_custom_fields_parameters.go
+++ b/kbclient/subscription/get_subscription_custom_fields_parameters.go
@@ -74,10 +74,6 @@ for the get subscription custom fields operation typically these are written to 
 */
 type GetSubscriptionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*SubscriptionID*/
@@ -123,28 +119,6 @@ func (o *GetSubscriptionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get subscription custom fields params
-func (o *GetSubscriptionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetSubscriptionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get subscription custom fields params
-func (o *GetSubscriptionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get subscription custom fields params
-func (o *GetSubscriptionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetSubscriptionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get subscription custom fields params
-func (o *GetSubscriptionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get subscription custom fields params
 func (o *GetSubscriptionCustomFieldsParams) WithAudit(audit *string) *GetSubscriptionCustomFieldsParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetSubscriptionCustomFieldsParams) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/subscription/get_subscription_parameters.go
+++ b/kbclient/subscription/get_subscription_parameters.go
@@ -74,10 +74,6 @@ for the get subscription operation typically these are written to a http.Request
 */
 type GetSubscriptionParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*SubscriptionID*/
@@ -123,28 +119,6 @@ func (o *GetSubscriptionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get subscription params
-func (o *GetSubscriptionParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetSubscriptionParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get subscription params
-func (o *GetSubscriptionParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get subscription params
-func (o *GetSubscriptionParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetSubscriptionParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get subscription params
-func (o *GetSubscriptionParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get subscription params
 func (o *GetSubscriptionParams) WithAudit(audit *string) *GetSubscriptionParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetSubscriptionParams) WriteToRequest(r runtime.ClientRequest, reg strf
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/subscription/get_subscription_tags_parameters.go
+++ b/kbclient/subscription/get_subscription_tags_parameters.go
@@ -83,10 +83,6 @@ for the get subscription tags operation typically these are written to a http.Re
 */
 type GetSubscriptionTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*IncludedDeleted*/
@@ -134,28 +130,6 @@ func (o *GetSubscriptionTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get subscription tags params
-func (o *GetSubscriptionTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetSubscriptionTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get subscription tags params
-func (o *GetSubscriptionTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get subscription tags params
-func (o *GetSubscriptionTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetSubscriptionTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get subscription tags params
-func (o *GetSubscriptionTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get subscription tags params
 func (o *GetSubscriptionTagsParams) WithAudit(audit *string) *GetSubscriptionTagsParams {
 	o.SetAudit(audit)
@@ -196,16 +170,6 @@ func (o *GetSubscriptionTagsParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/subscription/modify_subscription_custom_fields_parameters.go
+++ b/kbclient/subscription/modify_subscription_custom_fields_parameters.go
@@ -64,10 +64,6 @@ for the modify subscription custom fields operation typically these are written 
 */
 type ModifySubscriptionCustomFieldsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -117,28 +113,6 @@ func (o *ModifySubscriptionCustomFieldsParams) WithHTTPClient(client *http.Clien
 // SetHTTPClient adds the HTTPClient to the modify subscription custom fields params
 func (o *ModifySubscriptionCustomFieldsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the modify subscription custom fields params
-func (o *ModifySubscriptionCustomFieldsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *ModifySubscriptionCustomFieldsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the modify subscription custom fields params
-func (o *ModifySubscriptionCustomFieldsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the modify subscription custom fields params
-func (o *ModifySubscriptionCustomFieldsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *ModifySubscriptionCustomFieldsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the modify subscription custom fields params
-func (o *ModifySubscriptionCustomFieldsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the modify subscription custom fields params
@@ -203,16 +177,6 @@ func (o *ModifySubscriptionCustomFieldsParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/subscription_client.go
+++ b/kbclient/subscription/subscription_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -149,31 +145,18 @@ func (a *Client) AddSubscriptionBlockingState(ctx context.Context, params *AddSu
 	getParams := NewAddSubscriptionBlockingStateParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -230,14 +213,6 @@ func (a *Client) CancelSubscriptionPlan(ctx context.Context, params *CancelSubsc
 		params = NewCancelSubscriptionPlanParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -283,14 +258,6 @@ func (a *Client) ChangeSubscriptionPlan(ctx context.Context, params *ChangeSubsc
 		params = NewChangeSubscriptionPlanParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -338,31 +305,18 @@ func (a *Client) CreateSubscription(ctx context.Context, params *CreateSubscript
 	getParams := NewCreateSubscriptionParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -421,31 +375,18 @@ func (a *Client) CreateSubscriptionCustomFields(ctx context.Context, params *Cre
 	getParams := NewCreateSubscriptionCustomFieldsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -504,31 +445,18 @@ func (a *Client) CreateSubscriptionTags(ctx context.Context, params *CreateSubsc
 	getParams := NewCreateSubscriptionTagsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -587,31 +515,18 @@ func (a *Client) CreateSubscriptionWithAddOns(ctx context.Context, params *Creat
 	getParams := NewCreateSubscriptionWithAddOnsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -670,31 +585,18 @@ func (a *Client) CreateSubscriptionsWithAddOns(ctx context.Context, params *Crea
 	getParams := NewCreateSubscriptionsWithAddOnsParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -751,14 +653,6 @@ func (a *Client) DeleteSubscriptionCustomFields(ctx context.Context, params *Del
 		params = NewDeleteSubscriptionCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -804,14 +698,6 @@ func (a *Client) DeleteSubscriptionTags(ctx context.Context, params *DeleteSubsc
 		params = NewDeleteSubscriptionTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -857,14 +743,6 @@ func (a *Client) GetSubscription(ctx context.Context, params *GetSubscriptionPar
 		params = NewGetSubscriptionParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -898,14 +776,6 @@ func (a *Client) GetSubscriptionCustomFields(ctx context.Context, params *GetSub
 		params = NewGetSubscriptionCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -939,14 +809,6 @@ func (a *Client) GetSubscriptionTags(ctx context.Context, params *GetSubscriptio
 		params = NewGetSubscriptionTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -980,14 +842,6 @@ func (a *Client) ModifySubscriptionCustomFields(ctx context.Context, params *Mod
 		params = NewModifySubscriptionCustomFieldsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1033,14 +887,6 @@ func (a *Client) UncancelSubscriptionPlan(ctx context.Context, params *UncancelS
 		params = NewUncancelSubscriptionPlanParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1086,14 +932,6 @@ func (a *Client) UndoChangeSubscriptionPlan(ctx context.Context, params *UndoCha
 		params = NewUndoChangeSubscriptionPlanParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -1139,14 +977,6 @@ func (a *Client) UpdateSubscriptionBCD(ctx context.Context, params *UpdateSubscr
 		params = NewUpdateSubscriptionBCDParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbclient/subscription/uncancel_subscription_plan_parameters.go
+++ b/kbclient/subscription/uncancel_subscription_plan_parameters.go
@@ -63,10 +63,6 @@ for the uncancel subscription plan operation typically these are written to a ht
 */
 type UncancelSubscriptionPlanParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *UncancelSubscriptionPlanParams) WithHTTPClient(client *http.Client) *Un
 // SetHTTPClient adds the HTTPClient to the uncancel subscription plan params
 func (o *UncancelSubscriptionPlanParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the uncancel subscription plan params
-func (o *UncancelSubscriptionPlanParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UncancelSubscriptionPlanParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the uncancel subscription plan params
-func (o *UncancelSubscriptionPlanParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the uncancel subscription plan params
-func (o *UncancelSubscriptionPlanParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UncancelSubscriptionPlanParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the uncancel subscription plan params
-func (o *UncancelSubscriptionPlanParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the uncancel subscription plan params
@@ -202,16 +176,6 @@ func (o *UncancelSubscriptionPlanParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/undo_change_subscription_plan_parameters.go
+++ b/kbclient/subscription/undo_change_subscription_plan_parameters.go
@@ -63,10 +63,6 @@ for the undo change subscription plan operation typically these are written to a
 */
 type UndoChangeSubscriptionPlanParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -116,28 +112,6 @@ func (o *UndoChangeSubscriptionPlanParams) WithHTTPClient(client *http.Client) *
 // SetHTTPClient adds the HTTPClient to the undo change subscription plan params
 func (o *UndoChangeSubscriptionPlanParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the undo change subscription plan params
-func (o *UndoChangeSubscriptionPlanParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UndoChangeSubscriptionPlanParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the undo change subscription plan params
-func (o *UndoChangeSubscriptionPlanParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the undo change subscription plan params
-func (o *UndoChangeSubscriptionPlanParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UndoChangeSubscriptionPlanParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the undo change subscription plan params
-func (o *UndoChangeSubscriptionPlanParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the undo change subscription plan params
@@ -202,16 +176,6 @@ func (o *UndoChangeSubscriptionPlanParams) WriteToRequest(r runtime.ClientReques
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/subscription/update_subscription_b_c_d_parameters.go
+++ b/kbclient/subscription/update_subscription_b_c_d_parameters.go
@@ -77,10 +77,6 @@ for the update subscription b c d operation typically these are written to a htt
 */
 type UpdateSubscriptionBCDParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -134,28 +130,6 @@ func (o *UpdateSubscriptionBCDParams) WithHTTPClient(client *http.Client) *Updat
 // SetHTTPClient adds the HTTPClient to the update subscription b c d params
 func (o *UpdateSubscriptionBCDParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the update subscription b c d params
-func (o *UpdateSubscriptionBCDParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UpdateSubscriptionBCDParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the update subscription b c d params
-func (o *UpdateSubscriptionBCDParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the update subscription b c d params
-func (o *UpdateSubscriptionBCDParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UpdateSubscriptionBCDParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the update subscription b c d params
-func (o *UpdateSubscriptionBCDParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the update subscription b c d params
@@ -242,16 +216,6 @@ func (o *UpdateSubscriptionBCDParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tag/get_tag_audit_logs_with_history_parameters.go
+++ b/kbclient/tag/get_tag_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get tag audit logs with history operation typically these are written to
 */
 type GetTagAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*TagID*/
 	TagID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetTagAuditLogsWithHistoryParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get tag audit logs with history params
-func (o *GetTagAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTagAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get tag audit logs with history params
-func (o *GetTagAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get tag audit logs with history params
-func (o *GetTagAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTagAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get tag audit logs with history params
-func (o *GetTagAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithTagID adds the tagID to the get tag audit logs with history params
 func (o *GetTagAuditLogsWithHistoryParams) WithTagID(tagID strfmt.UUID) *GetTagAuditLogsWithHistoryParams {
 	o.SetTagID(tagID)
@@ -149,16 +123,6 @@ func (o *GetTagAuditLogsWithHistoryParams) WriteToRequest(r runtime.ClientReques
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param tagId
 	if err := r.SetPathParam("tagId", o.TagID.String()); err != nil {

--- a/kbclient/tag/get_tags_parameters.go
+++ b/kbclient/tag/get_tags_parameters.go
@@ -91,10 +91,6 @@ for the get tags operation typically these are written to a http.Request
 */
 type GetTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -142,28 +138,6 @@ func (o *GetTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get tags params
-func (o *GetTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get tags params
-func (o *GetTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get tags params
-func (o *GetTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get tags params
-func (o *GetTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get tags params
 func (o *GetTagsParams) WithAudit(audit *string) *GetTagsParams {
 	o.SetAudit(audit)
@@ -204,16 +178,6 @@ func (o *GetTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regis
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/tag/search_tags_parameters.go
+++ b/kbclient/tag/search_tags_parameters.go
@@ -91,10 +91,6 @@ for the search tags operation typically these are written to a http.Request
 */
 type SearchTagsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*Limit*/
@@ -142,28 +138,6 @@ func (o *SearchTagsParams) WithHTTPClient(client *http.Client) *SearchTagsParams
 // SetHTTPClient adds the HTTPClient to the search tags params
 func (o *SearchTagsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the search tags params
-func (o *SearchTagsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *SearchTagsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the search tags params
-func (o *SearchTagsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the search tags params
-func (o *SearchTagsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *SearchTagsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the search tags params
-func (o *SearchTagsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithAudit adds the audit to the search tags params
@@ -217,16 +191,6 @@ func (o *SearchTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/tag/tag_client.go
+++ b/kbclient/tag/tag_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -76,14 +72,6 @@ func (a *Client) GetTagAuditLogsWithHistory(ctx context.Context, params *GetTagA
 		params = NewGetTagAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -117,14 +105,6 @@ func (a *Client) GetTags(ctx context.Context, params *GetTagsParams) (*GetTagsOK
 		params = NewGetTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -158,14 +138,6 @@ func (a *Client) SearchTags(ctx context.Context, params *SearchTagsParams) (*Sea
 		params = NewSearchTagsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/tag_definition/create_tag_definition_parameters.go
+++ b/kbclient/tag_definition/create_tag_definition_parameters.go
@@ -64,10 +64,6 @@ for the create tag definition operation typically these are written to a http.Re
 */
 type CreateTagDefinitionParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *CreateTagDefinitionParams) WithHTTPClient(client *http.Client) *CreateT
 // SetHTTPClient adds the HTTPClient to the create tag definition params
 func (o *CreateTagDefinitionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the create tag definition params
-func (o *CreateTagDefinitionParams) WithXKillbillAPIKey(xKillbillAPIKey string) *CreateTagDefinitionParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the create tag definition params
-func (o *CreateTagDefinitionParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the create tag definition params
-func (o *CreateTagDefinitionParams) WithXKillbillAPISecret(xKillbillAPISecret string) *CreateTagDefinitionParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the create tag definition params
-func (o *CreateTagDefinitionParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the create tag definition params
@@ -190,16 +164,6 @@ func (o *CreateTagDefinitionParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tag_definition/delete_tag_definition_parameters.go
+++ b/kbclient/tag_definition/delete_tag_definition_parameters.go
@@ -62,10 +62,6 @@ for the delete tag definition operation typically these are written to a http.Re
 */
 type DeleteTagDefinitionParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *DeleteTagDefinitionParams) WithHTTPClient(client *http.Client) *DeleteT
 // SetHTTPClient adds the HTTPClient to the delete tag definition params
 func (o *DeleteTagDefinitionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete tag definition params
-func (o *DeleteTagDefinitionParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteTagDefinitionParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete tag definition params
-func (o *DeleteTagDefinitionParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete tag definition params
-func (o *DeleteTagDefinitionParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteTagDefinitionParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete tag definition params
-func (o *DeleteTagDefinitionParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete tag definition params
@@ -188,16 +162,6 @@ func (o *DeleteTagDefinitionParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tag_definition/get_tag_definition_audit_logs_with_history_parameters.go
+++ b/kbclient/tag_definition/get_tag_definition_audit_logs_with_history_parameters.go
@@ -62,10 +62,6 @@ for the get tag definition audit logs with history operation typically these are
 */
 type GetTagDefinitionAuditLogsWithHistoryParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*TagDefinitionID*/
 	TagDefinitionID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetTagDefinitionAuditLogsWithHistoryParams) SetHTTPClient(client *http.
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get tag definition audit logs with history params
-func (o *GetTagDefinitionAuditLogsWithHistoryParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTagDefinitionAuditLogsWithHistoryParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get tag definition audit logs with history params
-func (o *GetTagDefinitionAuditLogsWithHistoryParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get tag definition audit logs with history params
-func (o *GetTagDefinitionAuditLogsWithHistoryParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTagDefinitionAuditLogsWithHistoryParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get tag definition audit logs with history params
-func (o *GetTagDefinitionAuditLogsWithHistoryParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithTagDefinitionID adds the tagDefinitionID to the get tag definition audit logs with history params
 func (o *GetTagDefinitionAuditLogsWithHistoryParams) WithTagDefinitionID(tagDefinitionID strfmt.UUID) *GetTagDefinitionAuditLogsWithHistoryParams {
 	o.SetTagDefinitionID(tagDefinitionID)
@@ -149,16 +123,6 @@ func (o *GetTagDefinitionAuditLogsWithHistoryParams) WriteToRequest(r runtime.Cl
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param tagDefinitionId
 	if err := r.SetPathParam("tagDefinitionId", o.TagDefinitionID.String()); err != nil {

--- a/kbclient/tag_definition/get_tag_definition_parameters.go
+++ b/kbclient/tag_definition/get_tag_definition_parameters.go
@@ -74,10 +74,6 @@ for the get tag definition operation typically these are written to a http.Reque
 */
 type GetTagDefinitionParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 	/*TagDefinitionID*/
@@ -123,28 +119,6 @@ func (o *GetTagDefinitionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get tag definition params
-func (o *GetTagDefinitionParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTagDefinitionParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get tag definition params
-func (o *GetTagDefinitionParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get tag definition params
-func (o *GetTagDefinitionParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTagDefinitionParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get tag definition params
-func (o *GetTagDefinitionParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get tag definition params
 func (o *GetTagDefinitionParams) WithAudit(audit *string) *GetTagDefinitionParams {
 	o.SetAudit(audit)
@@ -174,16 +148,6 @@ func (o *GetTagDefinitionParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/tag_definition/get_tag_definitions_parameters.go
+++ b/kbclient/tag_definition/get_tag_definitions_parameters.go
@@ -74,10 +74,6 @@ for the get tag definitions operation typically these are written to a http.Requ
 */
 type GetTagDefinitionsParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*Audit*/
 	Audit *string
 
@@ -121,28 +117,6 @@ func (o *GetTagDefinitionsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get tag definitions params
-func (o *GetTagDefinitionsParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTagDefinitionsParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get tag definitions params
-func (o *GetTagDefinitionsParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get tag definitions params
-func (o *GetTagDefinitionsParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTagDefinitionsParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get tag definitions params
-func (o *GetTagDefinitionsParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithAudit adds the audit to the get tag definitions params
 func (o *GetTagDefinitionsParams) WithAudit(audit *string) *GetTagDefinitionsParams {
 	o.SetAudit(audit)
@@ -161,16 +135,6 @@ func (o *GetTagDefinitionsParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.Audit != nil {
 

--- a/kbclient/tag_definition/tag_definition_client.go
+++ b/kbclient/tag_definition/tag_definition_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -89,31 +85,18 @@ func (a *Client) CreateTagDefinition(ctx context.Context, params *CreateTagDefin
 	getParams := NewCreateTagDefinitionParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -170,14 +153,6 @@ func (a *Client) DeleteTagDefinition(ctx context.Context, params *DeleteTagDefin
 		params = NewDeleteTagDefinitionParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -223,14 +198,6 @@ func (a *Client) GetTagDefinition(ctx context.Context, params *GetTagDefinitionP
 		params = NewGetTagDefinitionParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -264,14 +231,6 @@ func (a *Client) GetTagDefinitionAuditLogsWithHistory(ctx context.Context, param
 		params = NewGetTagDefinitionAuditLogsWithHistoryParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -305,14 +264,6 @@ func (a *Client) GetTagDefinitions(ctx context.Context, params *GetTagDefinition
 		params = NewGetTagDefinitionsParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/tenant/delete_per_tenant_configuration_parameters.go
+++ b/kbclient/tenant/delete_per_tenant_configuration_parameters.go
@@ -62,10 +62,6 @@ for the delete per tenant configuration operation typically these are written to
 */
 type DeletePerTenantConfigurationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *DeletePerTenantConfigurationParams) SetHTTPClient(client *http.Client) 
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete per tenant configuration params
-func (o *DeletePerTenantConfigurationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePerTenantConfigurationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete per tenant configuration params
-func (o *DeletePerTenantConfigurationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete per tenant configuration params
-func (o *DeletePerTenantConfigurationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePerTenantConfigurationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete per tenant configuration params
-func (o *DeletePerTenantConfigurationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithXKillbillComment adds the xKillbillComment to the delete per tenant configuration params
 func (o *DeletePerTenantConfigurationParams) WithXKillbillComment(xKillbillComment *string) *DeletePerTenantConfigurationParams {
 	o.SetXKillbillComment(xKillbillComment)
@@ -175,16 +149,6 @@ func (o *DeletePerTenantConfigurationParams) WriteToRequest(r runtime.ClientRequ
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/delete_plugin_configuration_parameters.go
+++ b/kbclient/tenant/delete_plugin_configuration_parameters.go
@@ -62,10 +62,6 @@ for the delete plugin configuration operation typically these are written to a h
 */
 type DeletePluginConfigurationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *DeletePluginConfigurationParams) WithHTTPClient(client *http.Client) *D
 // SetHTTPClient adds the HTTPClient to the delete plugin configuration params
 func (o *DeletePluginConfigurationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete plugin configuration params
-func (o *DeletePluginConfigurationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePluginConfigurationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete plugin configuration params
-func (o *DeletePluginConfigurationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete plugin configuration params
-func (o *DeletePluginConfigurationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePluginConfigurationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete plugin configuration params
-func (o *DeletePluginConfigurationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete plugin configuration params
@@ -188,16 +162,6 @@ func (o *DeletePluginConfigurationParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/delete_plugin_payment_state_machine_config_parameters.go
+++ b/kbclient/tenant/delete_plugin_payment_state_machine_config_parameters.go
@@ -62,10 +62,6 @@ for the delete plugin payment state machine config operation typically these are
 */
 type DeletePluginPaymentStateMachineConfigParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *DeletePluginPaymentStateMachineConfigParams) WithHTTPClient(client *htt
 // SetHTTPClient adds the HTTPClient to the delete plugin payment state machine config params
 func (o *DeletePluginPaymentStateMachineConfigParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete plugin payment state machine config params
-func (o *DeletePluginPaymentStateMachineConfigParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePluginPaymentStateMachineConfigParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete plugin payment state machine config params
-func (o *DeletePluginPaymentStateMachineConfigParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete plugin payment state machine config params
-func (o *DeletePluginPaymentStateMachineConfigParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePluginPaymentStateMachineConfigParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete plugin payment state machine config params
-func (o *DeletePluginPaymentStateMachineConfigParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete plugin payment state machine config params
@@ -188,16 +162,6 @@ func (o *DeletePluginPaymentStateMachineConfigParams) WriteToRequest(r runtime.C
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/delete_push_notification_callbacks_parameters.go
+++ b/kbclient/tenant/delete_push_notification_callbacks_parameters.go
@@ -62,10 +62,6 @@ for the delete push notification callbacks operation typically these are written
 */
 type DeletePushNotificationCallbacksParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *DeletePushNotificationCallbacksParams) SetHTTPClient(client *http.Clien
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete push notification callbacks params
-func (o *DeletePushNotificationCallbacksParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeletePushNotificationCallbacksParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete push notification callbacks params
-func (o *DeletePushNotificationCallbacksParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete push notification callbacks params
-func (o *DeletePushNotificationCallbacksParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeletePushNotificationCallbacksParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete push notification callbacks params
-func (o *DeletePushNotificationCallbacksParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithXKillbillComment adds the xKillbillComment to the delete push notification callbacks params
 func (o *DeletePushNotificationCallbacksParams) WithXKillbillComment(xKillbillComment *string) *DeletePushNotificationCallbacksParams {
 	o.SetXKillbillComment(xKillbillComment)
@@ -175,16 +149,6 @@ func (o *DeletePushNotificationCallbacksParams) WriteToRequest(r runtime.ClientR
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/delete_user_key_value_parameters.go
+++ b/kbclient/tenant/delete_user_key_value_parameters.go
@@ -62,10 +62,6 @@ for the delete user key value operation typically these are written to a http.Re
 */
 type DeleteUserKeyValueParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *DeleteUserKeyValueParams) WithHTTPClient(client *http.Client) *DeleteUs
 // SetHTTPClient adds the HTTPClient to the delete user key value params
 func (o *DeleteUserKeyValueParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the delete user key value params
-func (o *DeleteUserKeyValueParams) WithXKillbillAPIKey(xKillbillAPIKey string) *DeleteUserKeyValueParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the delete user key value params
-func (o *DeleteUserKeyValueParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the delete user key value params
-func (o *DeleteUserKeyValueParams) WithXKillbillAPISecret(xKillbillAPISecret string) *DeleteUserKeyValueParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the delete user key value params
-func (o *DeleteUserKeyValueParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the delete user key value params
@@ -188,16 +162,6 @@ func (o *DeleteUserKeyValueParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/get_all_plugin_configuration_parameters.go
+++ b/kbclient/tenant/get_all_plugin_configuration_parameters.go
@@ -62,10 +62,6 @@ for the get all plugin configuration operation typically these are written to a 
 */
 type GetAllPluginConfigurationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*KeyPrefix*/
 	KeyPrefix string
 
@@ -109,28 +105,6 @@ func (o *GetAllPluginConfigurationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get all plugin configuration params
-func (o *GetAllPluginConfigurationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAllPluginConfigurationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get all plugin configuration params
-func (o *GetAllPluginConfigurationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get all plugin configuration params
-func (o *GetAllPluginConfigurationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAllPluginConfigurationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get all plugin configuration params
-func (o *GetAllPluginConfigurationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithKeyPrefix adds the keyPrefix to the get all plugin configuration params
 func (o *GetAllPluginConfigurationParams) WithKeyPrefix(keyPrefix string) *GetAllPluginConfigurationParams {
 	o.SetKeyPrefix(keyPrefix)
@@ -149,16 +123,6 @@ func (o *GetAllPluginConfigurationParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param keyPrefix
 	if err := r.SetPathParam("keyPrefix", o.KeyPrefix); err != nil {

--- a/kbclient/tenant/get_per_tenant_configuration_parameters.go
+++ b/kbclient/tenant/get_per_tenant_configuration_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewGetPerTenantConfigurationParams creates a new GetPerTenantConfigurationParams object
 // with the default values initialized.
 func NewGetPerTenantConfigurationParams() *GetPerTenantConfigurationParams {
-	var ()
+
 	return &GetPerTenantConfigurationParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewGetPerTenantConfigurationParams() *GetPerTenantConfigurationParams {
 // NewGetPerTenantConfigurationParamsWithTimeout creates a new GetPerTenantConfigurationParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetPerTenantConfigurationParamsWithTimeout(timeout time.Duration) *GetPerTenantConfigurationParams {
-	var ()
+
 	return &GetPerTenantConfigurationParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewGetPerTenantConfigurationParamsWithTimeout(timeout time.Duration) *GetPe
 // NewGetPerTenantConfigurationParamsWithContext creates a new GetPerTenantConfigurationParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetPerTenantConfigurationParamsWithContext(ctx context.Context) *GetPerTenantConfigurationParams {
-	var ()
+
 	return &GetPerTenantConfigurationParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewGetPerTenantConfigurationParamsWithContext(ctx context.Context) *GetPerT
 // NewGetPerTenantConfigurationParamsWithHTTPClient creates a new GetPerTenantConfigurationParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetPerTenantConfigurationParamsWithHTTPClient(client *http.Client) *GetPerTenantConfigurationParams {
-	var ()
+
 	return &GetPerTenantConfigurationParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewGetPerTenantConfigurationParamsWithHTTPClient(client *http.Client) *GetP
 for the get per tenant configuration operation typically these are written to a http.Request
 */
 type GetPerTenantConfigurationParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *GetPerTenantConfigurationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get per tenant configuration params
-func (o *GetPerTenantConfigurationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPerTenantConfigurationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get per tenant configuration params
-func (o *GetPerTenantConfigurationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get per tenant configuration params
-func (o *GetPerTenantConfigurationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPerTenantConfigurationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get per tenant configuration params
-func (o *GetPerTenantConfigurationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *GetPerTenantConfigurationParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *GetPerTenantConfigurationParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/tenant/get_plugin_configuration_parameters.go
+++ b/kbclient/tenant/get_plugin_configuration_parameters.go
@@ -62,10 +62,6 @@ for the get plugin configuration operation typically these are written to a http
 */
 type GetPluginConfigurationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*PluginName*/
 	PluginName string
 
@@ -109,28 +105,6 @@ func (o *GetPluginConfigurationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get plugin configuration params
-func (o *GetPluginConfigurationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPluginConfigurationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get plugin configuration params
-func (o *GetPluginConfigurationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get plugin configuration params
-func (o *GetPluginConfigurationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPluginConfigurationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get plugin configuration params
-func (o *GetPluginConfigurationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithPluginName adds the pluginName to the get plugin configuration params
 func (o *GetPluginConfigurationParams) WithPluginName(pluginName string) *GetPluginConfigurationParams {
 	o.SetPluginName(pluginName)
@@ -149,16 +123,6 @@ func (o *GetPluginConfigurationParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param pluginName
 	if err := r.SetPathParam("pluginName", o.PluginName); err != nil {

--- a/kbclient/tenant/get_plugin_payment_state_machine_config_parameters.go
+++ b/kbclient/tenant/get_plugin_payment_state_machine_config_parameters.go
@@ -62,10 +62,6 @@ for the get plugin payment state machine config operation typically these are wr
 */
 type GetPluginPaymentStateMachineConfigParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*PluginName*/
 	PluginName string
 
@@ -109,28 +105,6 @@ func (o *GetPluginPaymentStateMachineConfigParams) SetHTTPClient(client *http.Cl
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get plugin payment state machine config params
-func (o *GetPluginPaymentStateMachineConfigParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPluginPaymentStateMachineConfigParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get plugin payment state machine config params
-func (o *GetPluginPaymentStateMachineConfigParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get plugin payment state machine config params
-func (o *GetPluginPaymentStateMachineConfigParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPluginPaymentStateMachineConfigParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get plugin payment state machine config params
-func (o *GetPluginPaymentStateMachineConfigParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithPluginName adds the pluginName to the get plugin payment state machine config params
 func (o *GetPluginPaymentStateMachineConfigParams) WithPluginName(pluginName string) *GetPluginPaymentStateMachineConfigParams {
 	o.SetPluginName(pluginName)
@@ -149,16 +123,6 @@ func (o *GetPluginPaymentStateMachineConfigParams) WriteToRequest(r runtime.Clie
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param pluginName
 	if err := r.SetPathParam("pluginName", o.PluginName); err != nil {

--- a/kbclient/tenant/get_push_notification_callbacks_parameters.go
+++ b/kbclient/tenant/get_push_notification_callbacks_parameters.go
@@ -21,7 +21,7 @@ import (
 // NewGetPushNotificationCallbacksParams creates a new GetPushNotificationCallbacksParams object
 // with the default values initialized.
 func NewGetPushNotificationCallbacksParams() *GetPushNotificationCallbacksParams {
-	var ()
+
 	return &GetPushNotificationCallbacksParams{
 
 		timeout: cr.DefaultTimeout,
@@ -31,7 +31,7 @@ func NewGetPushNotificationCallbacksParams() *GetPushNotificationCallbacksParams
 // NewGetPushNotificationCallbacksParamsWithTimeout creates a new GetPushNotificationCallbacksParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetPushNotificationCallbacksParamsWithTimeout(timeout time.Duration) *GetPushNotificationCallbacksParams {
-	var ()
+
 	return &GetPushNotificationCallbacksParams{
 
 		timeout: timeout,
@@ -41,7 +41,7 @@ func NewGetPushNotificationCallbacksParamsWithTimeout(timeout time.Duration) *Ge
 // NewGetPushNotificationCallbacksParamsWithContext creates a new GetPushNotificationCallbacksParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetPushNotificationCallbacksParamsWithContext(ctx context.Context) *GetPushNotificationCallbacksParams {
-	var ()
+
 	return &GetPushNotificationCallbacksParams{
 
 		Context: ctx,
@@ -51,7 +51,7 @@ func NewGetPushNotificationCallbacksParamsWithContext(ctx context.Context) *GetP
 // NewGetPushNotificationCallbacksParamsWithHTTPClient creates a new GetPushNotificationCallbacksParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetPushNotificationCallbacksParamsWithHTTPClient(client *http.Client) *GetPushNotificationCallbacksParams {
-	var ()
+
 	return &GetPushNotificationCallbacksParams{
 		HTTPClient: client,
 	}
@@ -61,12 +61,6 @@ func NewGetPushNotificationCallbacksParamsWithHTTPClient(client *http.Client) *G
 for the get push notification callbacks operation typically these are written to a http.Request
 */
 type GetPushNotificationCallbacksParams struct {
-
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
-
 	WithStackTrace        *bool // If set, returns full stack trace with error message
 	timeout               time.Duration
 	Context               context.Context
@@ -107,28 +101,6 @@ func (o *GetPushNotificationCallbacksParams) SetHTTPClient(client *http.Client) 
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get push notification callbacks params
-func (o *GetPushNotificationCallbacksParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetPushNotificationCallbacksParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get push notification callbacks params
-func (o *GetPushNotificationCallbacksParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get push notification callbacks params
-func (o *GetPushNotificationCallbacksParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetPushNotificationCallbacksParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get push notification callbacks params
-func (o *GetPushNotificationCallbacksParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *GetPushNotificationCallbacksParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -136,16 +108,6 @@ func (o *GetPushNotificationCallbacksParams) WriteToRequest(r runtime.ClientRequ
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// header param withStackTrace
 	if o.WithStackTrace != nil && *o.WithStackTrace {

--- a/kbclient/tenant/get_tenant_parameters.go
+++ b/kbclient/tenant/get_tenant_parameters.go
@@ -62,10 +62,6 @@ for the get tenant operation typically these are written to a http.Request
 */
 type GetTenantParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*TenantID*/
 	TenantID strfmt.UUID
 
@@ -109,28 +105,6 @@ func (o *GetTenantParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get tenant params
-func (o *GetTenantParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetTenantParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get tenant params
-func (o *GetTenantParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get tenant params
-func (o *GetTenantParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetTenantParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get tenant params
-func (o *GetTenantParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithTenantID adds the tenantID to the get tenant params
 func (o *GetTenantParams) WithTenantID(tenantID strfmt.UUID) *GetTenantParams {
 	o.SetTenantID(tenantID)
@@ -149,16 +123,6 @@ func (o *GetTenantParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param tenantId
 	if err := r.SetPathParam("tenantId", o.TenantID.String()); err != nil {

--- a/kbclient/tenant/get_user_key_value_parameters.go
+++ b/kbclient/tenant/get_user_key_value_parameters.go
@@ -62,10 +62,6 @@ for the get user key value operation typically these are written to a http.Reque
 */
 type GetUserKeyValueParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*KeyName*/
 	KeyName string
 
@@ -109,28 +105,6 @@ func (o *GetUserKeyValueParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get user key value params
-func (o *GetUserKeyValueParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetUserKeyValueParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get user key value params
-func (o *GetUserKeyValueParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get user key value params
-func (o *GetUserKeyValueParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetUserKeyValueParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get user key value params
-func (o *GetUserKeyValueParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithKeyName adds the keyName to the get user key value params
 func (o *GetUserKeyValueParams) WithKeyName(keyName string) *GetUserKeyValueParams {
 	o.SetKeyName(keyName)
@@ -149,16 +123,6 @@ func (o *GetUserKeyValueParams) WriteToRequest(r runtime.ClientRequest, reg strf
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	// path param keyName
 	if err := r.SetPathParam("keyName", o.KeyName); err != nil {

--- a/kbclient/tenant/insert_user_key_value_parameters.go
+++ b/kbclient/tenant/insert_user_key_value_parameters.go
@@ -62,10 +62,6 @@ for the insert user key value operation typically these are written to a http.Re
 */
 type InsertUserKeyValueParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *InsertUserKeyValueParams) WithHTTPClient(client *http.Client) *InsertUs
 // SetHTTPClient adds the HTTPClient to the insert user key value params
 func (o *InsertUserKeyValueParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the insert user key value params
-func (o *InsertUserKeyValueParams) WithXKillbillAPIKey(xKillbillAPIKey string) *InsertUserKeyValueParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the insert user key value params
-func (o *InsertUserKeyValueParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the insert user key value params
-func (o *InsertUserKeyValueParams) WithXKillbillAPISecret(xKillbillAPISecret string) *InsertUserKeyValueParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the insert user key value params
-func (o *InsertUserKeyValueParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the insert user key value params
@@ -201,16 +175,6 @@ func (o *InsertUserKeyValueParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/register_push_notification_callback_parameters.go
+++ b/kbclient/tenant/register_push_notification_callback_parameters.go
@@ -62,10 +62,6 @@ for the register push notification callback operation typically these are writte
 */
 type RegisterPushNotificationCallbackParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *RegisterPushNotificationCallbackParams) WithHTTPClient(client *http.Cli
 // SetHTTPClient adds the HTTPClient to the register push notification callback params
 func (o *RegisterPushNotificationCallbackParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the register push notification callback params
-func (o *RegisterPushNotificationCallbackParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RegisterPushNotificationCallbackParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the register push notification callback params
-func (o *RegisterPushNotificationCallbackParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the register push notification callback params
-func (o *RegisterPushNotificationCallbackParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RegisterPushNotificationCallbackParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the register push notification callback params
-func (o *RegisterPushNotificationCallbackParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the register push notification callback params
@@ -188,16 +162,6 @@ func (o *RegisterPushNotificationCallbackParams) WriteToRequest(r runtime.Client
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/tenant_client.go
+++ b/kbclient/tenant/tenant_client.go
@@ -26,10 +26,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -159,22 +155,18 @@ func (a *Client) CreateTenant(ctx context.Context, params *CreateTenantParams) (
 	getParams := NewCreateTenantParams()
 	getParams.Context = ctx
 	params.Context = ctx
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -231,14 +223,6 @@ func (a *Client) DeletePerTenantConfiguration(ctx context.Context, params *Delet
 		params = NewDeletePerTenantConfigurationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -284,14 +268,6 @@ func (a *Client) DeletePluginConfiguration(ctx context.Context, params *DeletePl
 		params = NewDeletePluginConfigurationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -337,14 +313,6 @@ func (a *Client) DeletePluginPaymentStateMachineConfig(ctx context.Context, para
 		params = NewDeletePluginPaymentStateMachineConfigParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -390,14 +358,6 @@ func (a *Client) DeletePushNotificationCallbacks(ctx context.Context, params *De
 		params = NewDeletePushNotificationCallbacksParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -443,14 +403,6 @@ func (a *Client) DeleteUserKeyValue(ctx context.Context, params *DeleteUserKeyVa
 		params = NewDeleteUserKeyValueParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
@@ -496,14 +448,6 @@ func (a *Client) GetAllPluginConfiguration(ctx context.Context, params *GetAllPl
 		params = NewGetAllPluginConfigurationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -537,14 +481,6 @@ func (a *Client) GetPerTenantConfiguration(ctx context.Context, params *GetPerTe
 		params = NewGetPerTenantConfigurationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -578,14 +514,6 @@ func (a *Client) GetPluginConfiguration(ctx context.Context, params *GetPluginCo
 		params = NewGetPluginConfigurationParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -619,14 +547,6 @@ func (a *Client) GetPluginPaymentStateMachineConfig(ctx context.Context, params 
 		params = NewGetPluginPaymentStateMachineConfigParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -660,14 +580,6 @@ func (a *Client) GetPushNotificationCallbacks(ctx context.Context, params *GetPu
 		params = NewGetPushNotificationCallbacksParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -701,14 +613,6 @@ func (a *Client) GetTenant(ctx context.Context, params *GetTenantParams) (*GetTe
 		params = NewGetTenantParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -742,7 +646,6 @@ func (a *Client) GetTenantByAPIKey(ctx context.Context, params *GetTenantByAPIKe
 		params = NewGetTenantByAPIKeyParams()
 	}
 	params.Context = ctx
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -776,14 +679,6 @@ func (a *Client) GetUserKeyValue(ctx context.Context, params *GetUserKeyValuePar
 		params = NewGetUserKeyValueParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -819,31 +714,18 @@ func (a *Client) InsertUserKeyValue(ctx context.Context, params *InsertUserKeyVa
 	getParams := NewInsertUserKeyValueParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -902,31 +784,18 @@ func (a *Client) RegisterPushNotificationCallback(ctx context.Context, params *R
 	getParams := NewRegisterPushNotificationCallbackParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -985,31 +854,18 @@ func (a *Client) UploadPerTenantConfiguration(ctx context.Context, params *Uploa
 	getParams := NewUploadPerTenantConfigurationParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1068,31 +924,18 @@ func (a *Client) UploadPluginConfiguration(ctx context.Context, params *UploadPl
 	getParams := NewUploadPluginConfigurationParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -1151,31 +994,18 @@ func (a *Client) UploadPluginPaymentStateMachineConfig(ctx context.Context, para
 	getParams := NewUploadPluginPaymentStateMachineConfigParams()
 	getParams.Context = ctx
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-	getParams.XKillbillAPIKey = params.XKillbillAPIKey
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-	getParams.XKillbillAPISecret = params.XKillbillAPISecret
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}
 	getParams.XKillbillComment = params.XKillbillComment
-
 	if params.XKillbillCreatedBy == "" && a.defaults.XKillbillCreatedBy() != nil {
 		params.XKillbillCreatedBy = *a.defaults.XKillbillCreatedBy()
 	}
 	getParams.XKillbillCreatedBy = params.XKillbillCreatedBy
-
 	if params.XKillbillReason == nil && a.defaults.XKillbillReason() != nil {
 		params.XKillbillReason = a.defaults.XKillbillReason()
 	}
 	getParams.XKillbillReason = params.XKillbillReason
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}

--- a/kbclient/tenant/upload_per_tenant_configuration_parameters.go
+++ b/kbclient/tenant/upload_per_tenant_configuration_parameters.go
@@ -62,10 +62,6 @@ for the upload per tenant configuration operation typically these are written to
 */
 type UploadPerTenantConfigurationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -113,28 +109,6 @@ func (o *UploadPerTenantConfigurationParams) WithHTTPClient(client *http.Client)
 // SetHTTPClient adds the HTTPClient to the upload per tenant configuration params
 func (o *UploadPerTenantConfigurationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload per tenant configuration params
-func (o *UploadPerTenantConfigurationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadPerTenantConfigurationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload per tenant configuration params
-func (o *UploadPerTenantConfigurationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload per tenant configuration params
-func (o *UploadPerTenantConfigurationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadPerTenantConfigurationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload per tenant configuration params
-func (o *UploadPerTenantConfigurationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload per tenant configuration params
@@ -188,16 +162,6 @@ func (o *UploadPerTenantConfigurationParams) WriteToRequest(r runtime.ClientRequ
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/upload_plugin_configuration_parameters.go
+++ b/kbclient/tenant/upload_plugin_configuration_parameters.go
@@ -62,10 +62,6 @@ for the upload plugin configuration operation typically these are written to a h
 */
 type UploadPluginConfigurationParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *UploadPluginConfigurationParams) WithHTTPClient(client *http.Client) *U
 // SetHTTPClient adds the HTTPClient to the upload plugin configuration params
 func (o *UploadPluginConfigurationParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload plugin configuration params
-func (o *UploadPluginConfigurationParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadPluginConfigurationParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload plugin configuration params
-func (o *UploadPluginConfigurationParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload plugin configuration params
-func (o *UploadPluginConfigurationParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadPluginConfigurationParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload plugin configuration params
-func (o *UploadPluginConfigurationParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload plugin configuration params
@@ -201,16 +175,6 @@ func (o *UploadPluginConfigurationParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/tenant/upload_plugin_payment_state_machine_config_parameters.go
+++ b/kbclient/tenant/upload_plugin_payment_state_machine_config_parameters.go
@@ -62,10 +62,6 @@ for the upload plugin payment state machine config operation typically these are
 */
 type UploadPluginPaymentStateMachineConfigParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *UploadPluginPaymentStateMachineConfigParams) WithHTTPClient(client *htt
 // SetHTTPClient adds the HTTPClient to the upload plugin payment state machine config params
 func (o *UploadPluginPaymentStateMachineConfigParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the upload plugin payment state machine config params
-func (o *UploadPluginPaymentStateMachineConfigParams) WithXKillbillAPIKey(xKillbillAPIKey string) *UploadPluginPaymentStateMachineConfigParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the upload plugin payment state machine config params
-func (o *UploadPluginPaymentStateMachineConfigParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the upload plugin payment state machine config params
-func (o *UploadPluginPaymentStateMachineConfigParams) WithXKillbillAPISecret(xKillbillAPISecret string) *UploadPluginPaymentStateMachineConfigParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the upload plugin payment state machine config params
-func (o *UploadPluginPaymentStateMachineConfigParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the upload plugin payment state machine config params
@@ -201,16 +175,6 @@ func (o *UploadPluginPaymentStateMachineConfigParams) WriteToRequest(r runtime.C
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/usage/get_all_usage_parameters.go
+++ b/kbclient/usage/get_all_usage_parameters.go
@@ -62,10 +62,6 @@ for the get all usage operation typically these are written to a http.Request
 */
 type GetAllUsageParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*EndDate*/
 	EndDate *strfmt.Date
 	/*StartDate*/
@@ -113,28 +109,6 @@ func (o *GetAllUsageParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get all usage params
-func (o *GetAllUsageParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetAllUsageParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get all usage params
-func (o *GetAllUsageParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get all usage params
-func (o *GetAllUsageParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetAllUsageParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get all usage params
-func (o *GetAllUsageParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
-}
-
 // WithEndDate adds the endDate to the get all usage params
 func (o *GetAllUsageParams) WithEndDate(endDate *strfmt.Date) *GetAllUsageParams {
 	o.SetEndDate(endDate)
@@ -175,16 +149,6 @@ func (o *GetAllUsageParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.EndDate != nil {
 

--- a/kbclient/usage/get_usage_parameters.go
+++ b/kbclient/usage/get_usage_parameters.go
@@ -62,10 +62,6 @@ for the get usage operation typically these are written to a http.Request
 */
 type GetUsageParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*EndDate*/
 	EndDate *strfmt.Date
 	/*StartDate*/
@@ -113,28 +109,6 @@ func (o *GetUsageParams) WithHTTPClient(client *http.Client) *GetUsageParams {
 // SetHTTPClient adds the HTTPClient to the get usage params
 func (o *GetUsageParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the get usage params
-func (o *GetUsageParams) WithXKillbillAPIKey(xKillbillAPIKey string) *GetUsageParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the get usage params
-func (o *GetUsageParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the get usage params
-func (o *GetUsageParams) WithXKillbillAPISecret(xKillbillAPISecret string) *GetUsageParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the get usage params
-func (o *GetUsageParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithEndDate adds the endDate to the get usage params
@@ -188,16 +162,6 @@ func (o *GetUsageParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.EndDate != nil {
 

--- a/kbclient/usage/record_usage_parameters.go
+++ b/kbclient/usage/record_usage_parameters.go
@@ -64,10 +64,6 @@ for the record usage operation typically these are written to a http.Request
 */
 type RecordUsageParams struct {
 
-	/*XKillbillAPIKey*/
-	XKillbillAPIKey string
-	/*XKillbillAPISecret*/
-	XKillbillAPISecret string
 	/*XKillbillComment*/
 	XKillbillComment *string
 	/*XKillbillCreatedBy*/
@@ -115,28 +111,6 @@ func (o *RecordUsageParams) WithHTTPClient(client *http.Client) *RecordUsagePara
 // SetHTTPClient adds the HTTPClient to the record usage params
 func (o *RecordUsageParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithXKillbillAPIKey adds the xKillbillAPIKey to the record usage params
-func (o *RecordUsageParams) WithXKillbillAPIKey(xKillbillAPIKey string) *RecordUsageParams {
-	o.SetXKillbillAPIKey(xKillbillAPIKey)
-	return o
-}
-
-// SetXKillbillAPIKey adds the xKillbillApiKey to the record usage params
-func (o *RecordUsageParams) SetXKillbillAPIKey(xKillbillAPIKey string) {
-	o.XKillbillAPIKey = xKillbillAPIKey
-}
-
-// WithXKillbillAPISecret adds the xKillbillAPISecret to the record usage params
-func (o *RecordUsageParams) WithXKillbillAPISecret(xKillbillAPISecret string) *RecordUsageParams {
-	o.SetXKillbillAPISecret(xKillbillAPISecret)
-	return o
-}
-
-// SetXKillbillAPISecret adds the xKillbillApiSecret to the record usage params
-func (o *RecordUsageParams) SetXKillbillAPISecret(xKillbillAPISecret string) {
-	o.XKillbillAPISecret = xKillbillAPISecret
 }
 
 // WithXKillbillComment adds the xKillbillComment to the record usage params
@@ -190,16 +164,6 @@ func (o *RecordUsageParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
-	// header param X-Killbill-ApiKey
-	if err := r.SetHeaderParam("X-Killbill-ApiKey", o.XKillbillAPIKey); err != nil {
-		return err
-	}
-
-	// header param X-Killbill-ApiSecret
-	if err := r.SetHeaderParam("X-Killbill-ApiSecret", o.XKillbillAPISecret); err != nil {
-		return err
-	}
 
 	if o.XKillbillComment != nil {
 

--- a/kbclient/usage/usage_client.go
+++ b/kbclient/usage/usage_client.go
@@ -25,10 +25,6 @@ func New(transport runtime.ClientTransport,
 // killbill default values. When a call is made to an operation, these values are used
 // if params doesn't specify them.
 type KillbillDefaults interface {
-	// Default API Key. If not set explicitly in params, this will be used.
-	XKillbillAPIKey() *string
-	// Default API Secret. If not set explicitly in params, this will be used.
-	XKillbillAPISecret() *string
 	// Default CreatedBy. If not set explicitly in params, this will be used.
 	XKillbillCreatedBy() *string
 	// Default Comment. If not set explicitly in params, this will be used.
@@ -76,14 +72,6 @@ func (a *Client) GetAllUsage(ctx context.Context, params *GetAllUsageParams) (*G
 		params = NewGetAllUsageParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -117,14 +105,6 @@ func (a *Client) GetUsage(ctx context.Context, params *GetUsageParams) (*GetUsag
 		params = NewGetUsageParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.WithStackTrace == nil && a.defaults.KillbillWithStackTrace() != nil {
 		params.WithStackTrace = a.defaults.KillbillWithStackTrace()
 	}
@@ -158,14 +138,6 @@ func (a *Client) RecordUsage(ctx context.Context, params *RecordUsageParams) (*R
 		params = NewRecordUsageParams()
 	}
 	params.Context = ctx
-	if params.XKillbillAPIKey == "" && a.defaults.XKillbillAPIKey() != nil {
-		params.XKillbillAPIKey = *a.defaults.XKillbillAPIKey()
-	}
-
-	if params.XKillbillAPISecret == "" && a.defaults.XKillbillAPISecret() != nil {
-		params.XKillbillAPISecret = *a.defaults.XKillbillAPISecret()
-	}
-
 	if params.XKillbillComment == nil && a.defaults.XKillbillComment() != nil {
 		params.XKillbillComment = a.defaults.XKillbillComment()
 	}

--- a/kbmodel/account.go
+++ b/kbmodel/account.go
@@ -65,9 +65,6 @@ type Account struct {
 	// is migrated
 	IsMigrated *bool `json:"isMigrated,omitempty"`
 
-	// is notified for invoices
-	IsNotifiedForInvoices *bool `json:"isNotifiedForInvoices,omitempty"`
-
 	// is payment delegated to parent
 	IsPaymentDelegatedToParent *bool `json:"isPaymentDelegatedToParent,omitempty"`
 

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Kill Bill is an open-source billing and payments platform",
-    "version": "0.19.17-SNAPSHOT",
+    "version": "0.20.2-SNAPSHOT",
     "title": "Kill Bill",
     "contact": {
       "name": "killbilling-users@googlegroups.com"
@@ -14,19 +14,22 @@
   },
   "tags": [
     {
-      "name": "Account"
+      "name": "Overdue"
     },
     {
-      "name": "Subscription"
-    },
-    {
-      "name": "CustomField"
+      "name": "Usage"
     },
     {
       "name": "Catalog"
     },
     {
-      "name": "Invoice"
+      "name": "Credit"
+    },
+    {
+      "name": "PaymentMethod"
+    },
+    {
+      "name": "InvoicePayment"
     },
     {
       "name": "TagDefinition"
@@ -35,52 +38,49 @@
       "name": "Bundle"
     },
     {
-      "name": "Export"
+      "name": "PaymentGateway"
     },
     {
       "name": "PluginInfo"
     },
     {
-      "name": "Admin"
-    },
-    {
-      "name": "PaymentTransaction"
+      "name": "Security"
     },
     {
       "name": "InvoiceItem"
     },
     {
-      "name": "Overdue"
-    },
-    {
-      "name": "Security"
-    },
-    {
-      "name": "InvoicePayment"
-    },
-    {
-      "name": "PaymentMethod"
-    },
-    {
-      "name": "Tag"
-    },
-    {
-      "name": "Credit"
-    },
-    {
       "name": "NodesInfo"
-    },
-    {
-      "name": "PaymentGateway"
     },
     {
       "name": "Payment"
     },
     {
-      "name": "Usage"
+      "name": "Account"
+    },
+    {
+      "name": "Tag"
+    },
+    {
+      "name": "Subscription"
     },
     {
       "name": "Tenant"
+    },
+    {
+      "name": "CustomField"
+    },
+    {
+      "name": "PaymentTransaction"
+    },
+    {
+      "name": "Admin"
+    },
+    {
+      "name": "Export"
+    },
+    {
+      "name": "Invoice"
     }
   ],
   "paths": {
@@ -127,18 +127,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -155,6 +143,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -197,18 +191,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -225,6 +207,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -282,18 +270,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -310,6 +286,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -387,18 +369,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -433,6 +403,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -497,18 +473,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -525,6 +489,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -574,18 +544,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -605,6 +563,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -662,18 +626,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -687,6 +639,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -754,18 +712,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -779,6 +725,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -841,18 +793,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -875,6 +815,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -944,18 +890,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -978,6 +912,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1001,18 +941,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1032,6 +960,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1055,18 +989,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1086,6 +1008,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1146,18 +1074,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1177,6 +1093,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -1241,18 +1163,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1275,6 +1185,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1322,18 +1238,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1356,6 +1260,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1400,18 +1310,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1425,6 +1323,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1474,18 +1378,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1508,6 +1400,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1543,18 +1441,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1574,6 +1460,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -1627,18 +1519,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1658,6 +1538,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -1711,18 +1597,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1736,6 +1610,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -1789,18 +1669,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -1814,141 +1682,12 @@
         "security": [
           {
             "basicAuth": []
-          }
-        ]
-      }
-    },
-    "/1.0/kb/accounts/{accountId}/emailNotifications": {
-      "get": {
-        "tags": [
-          "Account"
-        ],
-        "summary": "Retrieve account email notification",
-        "description": "",
-        "operationId": "getEmailNotificationsForAccount",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "accountId",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
-            "format": "uuid"
           },
           {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
+            "Killbill Api Key": []
           },
           {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/InvoiceEmail"
-            }
-          },
-          "400": {
-            "description": "Invalid account id supplied"
-          },
-          "204": {
-            "description": "Successful operation"
-          },
-          "404": {
-            "description": "Account not found"
-          }
-        },
-        "security": [
-          {
-            "basicAuth": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "Account"
-        ],
-        "summary": "Set account email notification",
-        "description": "",
-        "operationId": "setEmailNotificationsForAccount",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "accountId",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
-            "format": "uuid"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/InvoiceEmail"
-            }
-          },
-          {
-            "name": "X-Killbill-CreatedBy",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-Reason",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-Comment",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Invalid account id supplied"
-          },
-          "204": {
-            "description": "Successful operation"
-          },
-          "404": {
-            "description": "Account not found"
-          }
-        },
-        "security": [
-          {
-            "basicAuth": []
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -1972,18 +1711,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2003,6 +1730,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -2053,18 +1786,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2087,6 +1808,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2118,18 +1845,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2149,6 +1864,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2196,18 +1917,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2221,6 +1930,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2280,18 +1995,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2314,6 +2017,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -2393,18 +2102,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2418,6 +2115,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2488,18 +2191,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2522,6 +2213,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2545,18 +2242,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2576,6 +2261,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2635,18 +2326,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2669,6 +2348,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -2753,18 +2438,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2784,6 +2457,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2841,18 +2520,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2869,6 +2536,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -2938,18 +2611,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -2966,6 +2627,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3025,18 +2692,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3056,6 +2711,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -3133,18 +2794,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3179,6 +2828,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3221,18 +2876,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3255,6 +2898,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -3309,18 +2958,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3340,6 +2977,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -3393,18 +3036,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3418,6 +3049,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3460,18 +3097,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3491,6 +3116,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3535,18 +3166,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3563,6 +3182,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3584,18 +3209,6 @@
             "in": "query",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3609,6 +3222,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3632,18 +3251,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3657,6 +3264,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3672,20 +3285,7 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "204": {
             "description": "Successful operation"
@@ -3694,6 +3294,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3709,20 +3315,7 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "204": {
             "description": "Successful operation"
@@ -3731,6 +3324,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -3744,20 +3343,7 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "204": {
             "description": "Successful operation"
@@ -3766,6 +3352,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3818,18 +3410,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3840,6 +3420,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3900,18 +3486,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -3925,6 +3499,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -3999,18 +3579,6 @@
             "required": false,
             "type": "boolean",
             "default": true
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4027,6 +3595,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4067,18 +3641,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4098,6 +3660,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4141,18 +3709,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4169,6 +3725,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4219,18 +3781,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4247,6 +3797,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4282,18 +3838,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4313,6 +3857,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -4393,18 +3943,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4424,6 +3962,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4490,18 +4034,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4524,6 +4056,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4559,18 +4097,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4590,6 +4116,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -4643,18 +4175,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4674,6 +4194,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -4727,18 +4253,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4752,6 +4266,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -4805,18 +4325,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4830,6 +4338,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4891,18 +4405,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4919,6 +4421,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -4968,18 +4476,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -4996,6 +4492,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5057,18 +4559,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5085,6 +4575,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5127,18 +4623,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5161,6 +4645,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -5215,18 +4705,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5246,6 +4724,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -5299,18 +4783,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5324,6 +4796,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5353,18 +4831,6 @@
             "required": false,
             "type": "string",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5381,6 +4847,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -5409,18 +4881,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5431,6 +4891,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5465,18 +4931,6 @@
             "required": false,
             "type": "string",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5493,6 +4947,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5515,18 +4975,6 @@
             "required": false,
             "type": "string",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5543,6 +4991,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5572,18 +5026,6 @@
             "required": false,
             "type": "string",
             "format": "date"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5597,6 +5039,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5626,18 +5074,6 @@
             "required": false,
             "type": "string",
             "format": "date"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5651,6 +5087,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5680,18 +5122,6 @@
             "required": false,
             "type": "string",
             "format": "date"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5705,6 +5135,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5734,18 +5170,6 @@
             "required": false,
             "type": "string",
             "format": "date"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5759,6 +5183,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5803,18 +5233,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5828,6 +5246,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5850,18 +5274,6 @@
             "required": false,
             "type": "string",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5879,6 +5291,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -5908,18 +5326,6 @@
             "required": false,
             "type": "string",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5933,6 +5339,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -5972,18 +5384,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -5997,6 +5397,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6058,18 +5464,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6089,6 +5483,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6112,18 +5512,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6143,6 +5531,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6186,18 +5580,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6214,6 +5596,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6264,18 +5652,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6292,6 +5668,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6315,18 +5697,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6346,6 +5716,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6387,18 +5763,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6415,6 +5779,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6450,18 +5820,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6481,6 +5839,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -6534,18 +5898,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6565,6 +5917,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -6618,18 +5976,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6643,6 +5989,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -6696,18 +6048,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6721,6 +6061,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -6770,18 +6116,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6804,6 +6138,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -6858,18 +6198,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6889,6 +6217,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -6942,18 +6276,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -6967,6 +6289,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -7026,18 +6354,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7057,6 +6373,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -7127,18 +6449,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7170,6 +6480,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -7206,6 +6522,16 @@
             }
           },
           {
+            "name": "pluginProperty",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
             "name": "X-Killbill-CreatedBy",
             "in": "header",
             "required": true,
@@ -7221,18 +6547,6 @@
             "name": "X-Killbill-Comment",
             "in": "header",
             "required": false,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
             "type": "string"
           }
         ],
@@ -7253,6 +6567,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -7289,6 +6609,16 @@
             }
           },
           {
+            "name": "pluginProperty",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
             "name": "X-Killbill-CreatedBy",
             "in": "header",
             "required": true,
@@ -7304,18 +6634,6 @@
             "name": "X-Killbill-Comment",
             "in": "header",
             "required": false,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
             "type": "string"
           }
         ],
@@ -7336,6 +6654,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -7371,18 +6695,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7402,6 +6714,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -7455,18 +6773,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7486,6 +6792,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -7539,18 +6851,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7564,6 +6864,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -7617,18 +6923,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7642,6 +6936,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -7718,18 +7018,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7749,6 +7037,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -7801,18 +7095,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7835,6 +7117,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -7889,18 +7177,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7920,6 +7196,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -7973,18 +7255,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -7998,6 +7268,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8048,18 +7324,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8076,6 +7340,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8125,18 +7395,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8153,6 +7411,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8202,18 +7466,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8230,6 +7482,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8252,18 +7510,6 @@
             "required": true,
             "type": "string",
             "pattern": ".*"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8283,6 +7529,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -8339,18 +7591,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8364,6 +7604,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8443,18 +7689,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8477,6 +7711,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8535,18 +7775,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8566,6 +7794,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8617,18 +7851,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8642,6 +7864,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8664,18 +7892,6 @@
             "required": true,
             "type": "string",
             "pattern": ".*"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8692,6 +7908,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8754,18 +7976,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8782,6 +7992,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8832,18 +8048,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8860,6 +8064,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -8917,18 +8127,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -8945,6 +8143,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9024,18 +8228,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9058,6 +8250,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9073,20 +8271,7 @@
         "produces": [
           "text/html"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -9101,6 +8286,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -9150,18 +8341,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9175,6 +8354,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9197,18 +8382,6 @@
             "required": true,
             "type": "string",
             "pattern": ".*"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9228,6 +8401,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -9284,18 +8463,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9309,6 +8476,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9358,18 +8531,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9389,6 +8550,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -9456,18 +8623,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9487,6 +8642,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9531,18 +8692,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9556,6 +8705,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9591,18 +8746,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9622,6 +8765,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -9675,18 +8824,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9706,6 +8843,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -9759,18 +8902,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9784,6 +8915,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -9837,18 +8974,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9862,6 +8987,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9885,18 +9016,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9913,6 +9032,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -9962,18 +9087,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -9996,6 +9109,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -10063,18 +9182,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10097,6 +9204,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -10139,18 +9252,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10173,6 +9274,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -10227,18 +9334,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10258,6 +9353,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -10311,18 +9412,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10336,6 +9425,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -10380,18 +9475,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10408,6 +9491,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -10467,18 +9556,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10495,6 +9572,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -10602,20 +9685,7 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -10627,6 +9697,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -10669,18 +9745,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10697,6 +9761,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -10712,20 +9782,7 @@
         "produces": [
           "text/xml"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -10737,6 +9794,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -10776,18 +9839,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10804,6 +9855,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -10868,18 +9925,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -10896,6 +9941,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -10975,18 +10026,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11003,6 +10042,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11074,18 +10119,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11096,6 +10129,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11153,18 +10192,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11181,6 +10208,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11247,18 +10280,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11275,6 +10296,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11348,18 +10375,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11376,6 +10391,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11435,18 +10456,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11466,6 +10475,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -11529,18 +10544,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11557,6 +10560,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11580,18 +10589,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11611,6 +10608,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11646,18 +10649,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11677,6 +10668,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -11730,18 +10727,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11761,6 +10746,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -11814,18 +10805,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11839,6 +10818,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -11892,18 +10877,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -11917,6 +10890,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -11974,18 +10953,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12002,6 +10969,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -12061,18 +11034,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12089,6 +11050,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -12149,18 +11116,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12180,6 +11135,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -12203,18 +11164,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12234,6 +11183,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -12269,18 +11224,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12300,6 +11243,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -12353,18 +11302,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12384,6 +11321,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -12437,18 +11380,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12462,6 +11393,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -12515,18 +11452,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12540,6 +11465,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -12582,18 +11513,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12616,6 +11535,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -12670,18 +11595,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12701,6 +11614,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -12754,18 +11673,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12779,6 +11686,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -12836,18 +11749,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12864,6 +11765,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -12926,18 +11833,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -12969,6 +11864,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -13031,18 +11932,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13071,6 +11960,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -13133,18 +12028,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13173,6 +12056,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13196,18 +12085,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13227,6 +12104,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13269,18 +12152,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13294,6 +12165,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13358,18 +12235,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13401,6 +12266,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13465,18 +12336,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13508,6 +12367,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13562,18 +12427,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13605,6 +12458,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13678,18 +12537,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13706,6 +12553,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13770,18 +12623,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13813,6 +12654,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13893,18 +12740,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -13921,6 +12756,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -13980,18 +12821,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14011,6 +12840,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -14081,18 +12916,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14127,6 +12950,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -14197,18 +13026,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14240,6 +13057,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -14310,18 +13133,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14353,6 +13164,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -14376,18 +13193,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14407,6 +13212,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -14479,18 +13290,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14525,6 +13324,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -14597,18 +13402,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14643,6 +13436,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -14678,18 +13477,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14709,6 +13496,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -14762,18 +13555,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14793,6 +13574,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -14846,18 +13633,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14871,6 +13646,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -14924,18 +13705,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -14949,6 +13718,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -15021,18 +13796,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -15067,6 +13830,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -15109,18 +13878,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -15143,6 +13900,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -15197,18 +13960,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -15228,6 +13979,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -15281,18 +14038,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -15306,6 +14051,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -15350,18 +14101,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -15375,6 +14114,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -15390,20 +14135,7 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -15418,6 +14150,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -15991,18 +14729,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16016,6 +14742,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -16116,18 +14848,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16141,6 +14861,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -16241,18 +14967,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16269,6 +14983,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -16304,18 +15024,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16335,6 +15043,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -16429,18 +15143,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16457,6 +15159,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -16557,18 +15265,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16585,6 +15281,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -16651,18 +15353,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16676,6 +15366,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -16742,18 +15438,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16776,6 +15460,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -16811,18 +15501,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16842,6 +15520,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -16895,18 +15579,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16920,6 +15592,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -16973,18 +15651,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -16998,6 +15664,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -17051,18 +15723,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17076,6 +15736,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17118,18 +15784,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17152,6 +15806,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -17204,18 +15864,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17229,6 +15877,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -17282,18 +15936,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17307,6 +15949,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17358,18 +16006,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17386,6 +16022,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17437,18 +16079,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17465,6 +16095,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17492,18 +16128,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17520,6 +16144,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -17562,18 +16192,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17590,6 +16208,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17625,18 +16249,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17653,6 +16265,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -17692,18 +16310,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17717,6 +16323,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17740,18 +16352,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17771,6 +16371,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17814,18 +16420,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17842,6 +16436,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17892,18 +16492,6 @@
               "MINIMAL",
               "NONE"
             ]
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17920,6 +16508,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -17943,18 +16537,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -17974,6 +16556,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -18091,20 +16679,7 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -18119,6 +16694,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18159,18 +16740,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18187,6 +16756,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18215,18 +16790,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18240,6 +16803,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -18255,20 +16824,7 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -18283,6 +16839,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18325,18 +16887,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18353,6 +16903,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18381,18 +16937,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18406,6 +16950,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -18428,18 +16978,6 @@
             "required": true,
             "type": "string",
             "pattern": ".*"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18456,6 +16994,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -18478,18 +17022,6 @@
             "required": true,
             "type": "string",
             "pattern": ".*"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18506,6 +17038,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18555,18 +17093,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18583,6 +17109,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18618,18 +17150,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18643,6 +17163,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -18665,18 +17191,6 @@
             "required": true,
             "type": "string",
             "pattern": ".*"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18693,6 +17207,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18742,18 +17262,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18770,6 +17278,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18805,18 +17319,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18830,6 +17332,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -18852,18 +17360,6 @@
             "required": true,
             "type": "string",
             "pattern": ".*"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18880,6 +17376,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18929,18 +17431,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -18957,6 +17447,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       },
@@ -18992,18 +17488,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -19017,6 +17501,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -19040,18 +17530,6 @@
             "type": "string",
             "pattern": "\\w+-\\w+-\\w+-\\w+-\\w+",
             "format": "uuid"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -19071,6 +17549,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -19115,18 +17599,6 @@
             "in": "header",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -19140,6 +17612,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -19177,18 +17655,6 @@
             "required": false,
             "type": "string",
             "format": "date"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -19205,6 +17671,12 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
@@ -19248,18 +17720,6 @@
             "required": false,
             "type": "string",
             "format": "date"
-          },
-          {
-            "name": "X-Killbill-ApiKey",
-            "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "X-Killbill-ApiSecret",
-            "in": "header",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -19276,12 +17736,28 @@
         "security": [
           {
             "basicAuth": []
+          },
+          {
+            "Killbill Api Key": []
+          },
+          {
+            "Killbill Api Secret": []
           }
         ]
       }
     }
   },
   "securityDefinitions": {
+    "Killbill Api Key": {
+      "type": "apiKey",
+      "name": "X-Killbill-ApiKey",
+      "in": "header"
+    },
+    "Killbill Api Secret": {
+      "type": "apiKey",
+      "name": "X-Killbill-ApiSecret",
+      "in": "header"
+    },
     "basicAuth": {
       "type": "basic"
     }
@@ -19290,10 +17766,6 @@
     "Entity": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string",
-          "format": "uuid"
-        },
         "createdDate": {
           "type": "string",
           "format": "date-time"
@@ -19301,6 +17773,10 @@
         "updatedDate": {
           "type": "string",
           "format": "date-time"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
         }
       }
     },
@@ -19548,10 +18024,6 @@
           "type": "string"
         },
         "isMigrated": {
-          "type": "boolean",
-          "default": false
-        },
-        "isNotifiedForInvoices": {
           "type": "boolean",
           "default": false
         },
@@ -19909,20 +18381,6 @@
         }
       }
     },
-    "AdminPayment": {
-      "type": "object",
-      "properties": {
-        "lastSuccessPaymentState": {
-          "type": "string"
-        },
-        "currentPaymentStateName": {
-          "type": "string"
-        },
-        "transactionStatus": {
-          "type": "string"
-        }
-      }
-    },
     "TenantKeyValue": {
       "type": "object",
       "properties": {
@@ -19934,6 +18392,20 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "AdminPayment": {
+      "type": "object",
+      "properties": {
+        "lastSuccessPaymentState": {
+          "type": "string"
+        },
+        "currentPaymentStateName": {
+          "type": "string"
+        },
+        "transactionStatus": {
+          "type": "string"
         }
       }
     },
@@ -20048,6 +18520,17 @@
         }
       }
     },
+    "NodeCommandProperty": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "object"
+        }
+      }
+    },
     "OverdueState": {
       "type": "object",
       "properties": {
@@ -20079,17 +18562,6 @@
         "reevaluationIntervalDays": {
           "type": "integer",
           "format": "int32"
-        }
-      }
-    },
-    "NodeCommandProperty": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "object"
         }
       }
     },
@@ -20707,6 +19179,28 @@
         }
       }
     },
+    "SubscriptionUsageRecord": {
+      "type": "object",
+      "required": [
+        "subscriptionId",
+        "unitUsageRecords"
+      ],
+      "properties": {
+        "subscriptionId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "trackingId": {
+          "type": "string"
+        },
+        "unitUsageRecords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UnitUsageRecord"
+          }
+        }
+      }
+    },
     "Subscription": {
       "type": "object",
       "required": [
@@ -20840,28 +19334,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/AuditLog"
-          }
-        }
-      }
-    },
-    "SubscriptionUsageRecord": {
-      "type": "object",
-      "required": [
-        "subscriptionId",
-        "unitUsageRecords"
-      ],
-      "properties": {
-        "subscriptionId": {
-          "type": "string",
-          "format": "uuid"
-        },
-        "trackingId": {
-          "type": "string"
-        },
-        "unitUsageRecords": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/UnitUsageRecord"
           }
         }
       }
@@ -22417,25 +20889,6 @@
         }
       }
     },
-    "InvoiceEmail": {
-      "type": "object",
-      "properties": {
-        "accountId": {
-          "type": "string",
-          "format": "uuid"
-        },
-        "isNotifiedForInvoices": {
-          "type": "boolean",
-          "default": false
-        },
-        "auditLogs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AuditLog"
-          }
-        }
-      }
-    },
     "TagDefinition": {
       "type": "object",
       "required": [
@@ -22524,6 +20977,35 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/TierPrice"
+          }
+        }
+      }
+    },
+    "Phase": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "prices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Price"
+          }
+        },
+        "fixedPrices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Price"
+          }
+        },
+        "duration": {
+          "$ref": "#/definitions/Duration"
+        },
+        "usages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Usage"
           }
         }
       }
@@ -22806,35 +21288,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/AuditLog"
-          }
-        }
-      }
-    },
-    "Phase": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "prices": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Price"
-          }
-        },
-        "fixedPrices": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Price"
-          }
-        },
-        "duration": {
-          "$ref": "#/definitions/Duration"
-        },
-        "usages": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Usage"
           }
         }
       }
@@ -23141,6 +21594,18 @@
         }
       }
     },
+    "RolledUpUnit": {
+      "type": "object",
+      "properties": {
+        "unitType": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
     "EventSubscription": {
       "type": "object",
       "properties": {
@@ -23218,18 +21683,6 @@
           "items": {
             "$ref": "#/definitions/AuditLog"
           }
-        }
-      }
-    },
-    "RolledUpUnit": {
-      "type": "object",
-      "properties": {
-        "unitType": {
-          "type": "string"
-        },
-        "amount": {
-          "type": "integer",
-          "format": "int64"
         }
       }
     },
@@ -23844,6 +22297,24 @@
         }
       }
     },
+    "RoleDefinition": {
+      "type": "object",
+      "required": [
+        "permissions",
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "AccountEmail": {
       "type": "object",
       "required": [
@@ -23861,24 +22332,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/AuditLog"
-          }
-        }
-      }
-    },
-    "RoleDefinition": {
-      "type": "object",
-      "required": [
-        "permissions",
-        "role"
-      ],
-      "properties": {
-        "role": {
-          "type": "string"
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "type": "string"
           }
         }
       }
@@ -24047,6 +22500,20 @@
         }
       }
     },
+    "Limit": {
+      "type": "object",
+      "properties": {
+        "unit": {
+          "type": "string"
+        },
+        "max": {
+          "type": "string"
+        },
+        "min": {
+          "type": "string"
+        }
+      }
+    },
     "Tag": {
       "type": "object",
       "properties": {
@@ -24094,20 +22561,6 @@
           "items": {
             "$ref": "#/definitions/AuditLog"
           }
-        }
-      }
-    },
-    "Limit": {
-      "type": "object",
-      "properties": {
-        "unit": {
-          "type": "string"
-        },
-        "max": {
-          "type": "string"
-        },
-        "min": {
-          "type": "string"
         }
       }
     },


### PR DESCRIPTION
 Remove API Key/Secret parameters: Recent killbill changes moved
 X-KillBill-ApiKey and X-KillBill-ApiSecret headers to security section.
 This change removes these parameters, and users are expected to use
 auth config to pass in these flags.

Add cirlceci config (version 2)

Reviewed-by: Dylan Swen <dswen@google.com>