### PR TITLE
kbcmd: various improvements

### DIFF
--- a/kbcmd/README.md
+++ b/kbcmd/README.md
@@ -21,6 +21,11 @@ source $GOPATH/src/github.com/killbill/kbcli/kbcmd/bash-autocomplete
 
 ## Running kbcmd
 ```bash
+export KB_API_KEY=bob
+export KB_API_SECRET=lazar
+export KB_API_CREATED_BY=$(whoami)
+export KB_HOST=127.0.0.1:8080
+
 kbcmd -h
 # (or)
 kbcmd <command> -h

--- a/kbcmd/cmdlib/registry.go
+++ b/kbcmd/cmdlib/registry.go
@@ -122,12 +122,14 @@ func (r *App) init() {
 		},
 		cli.StringFlag{
 			Name:        "api_key",
+			Value:       "bob",
 			Usage:       "Killbill API key X-Killbill-ApiKey",
 			Destination: &r.o.APIKey,
 			EnvVar:      "KB_API_KEY",
 		},
 		cli.StringFlag{
 			Name:        "api_secret",
+			Value:       "lazar",
 			Usage:       "Killbill API secret X-Killbill-ApiSecret",
 			Destination: &r.o.APISecret,
 			EnvVar:      "KB_API_SECRET",
@@ -190,7 +192,7 @@ func (r *App) toAction(fn HandlerFn) func(c *cli.Context) error {
 
 		// Set defaults
 
-		createdBy := os.Getenv("USER") + "-kbcmd"
+		createdBy := o.CreatedBy
 		comment := "Created by kbcmd tool"
 		reason := ""
 

--- a/kbcmd/commands/accounts/account.go
+++ b/kbcmd/commands/accounts/account.go
@@ -3,9 +3,8 @@ package accounts
 import (
 	"context"
 	"fmt"
-	"reflect"
-
 	"github.com/killbill/kbcli/kbcmd/cmdlib/args"
+	"reflect"
 
 	"github.com/killbill/kbcli/kbclient/account"
 	"github.com/killbill/kbcli/kbcmd/cmdlib"
@@ -150,9 +149,7 @@ func RegisterAccountCommands(r *cmdlib.App) {
 
 	// Create account
 	createAccountPropertyList = args.GetProperties(&kbmodel.Account{})
-	createAccountPropertyList.Get("ExternalKey").Required = true
-	createAccountPropertyList.Get("Email").Required = true
-	createAccountPropertyList.Get("Name").Required = true
+	createAccountPropertyList.Get("TimeZone").Default = "UTC"
 	createAccountPropertyList.Get("Currency").Default = string(kbmodel.AccountCurrencyUSD)
 	createAccountPropertyList.Sort(true, true)
 

--- a/kbcmd/commands/accounts/account.go
+++ b/kbcmd/commands/accounts/account.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/killbill/kbcli/kbcmd/cmdlib/args"
 	"reflect"
+	"time"
 
 	"github.com/killbill/kbcli/kbclient/account"
 	"github.com/killbill/kbcli/kbcmd/cmdlib"
@@ -63,7 +64,7 @@ func getAccount(ctx context.Context, o *cmdlib.Options) error {
 		return cmdlib.ErrorInvalidArgs
 	}
 
-	acc, err := kblib.GetAccountByKeyOrID(ctx, o.Client(), o.Args[0])
+	acc, err := kblib.GetAccountByKeyOrIDWithBalanceAndCBA(ctx, o.Client(), o.Args[0])
 	if err == nil {
 		o.Print(acc)
 	}
@@ -149,6 +150,7 @@ func RegisterAccountCommands(r *cmdlib.App) {
 
 	// Create account
 	createAccountPropertyList = args.GetProperties(&kbmodel.Account{})
+	createAccountPropertyList.Get("ReferenceTime").Default = time.Now().Format(time.RFC3339)
 	createAccountPropertyList.Get("TimeZone").Default = "UTC"
 	createAccountPropertyList.Get("Currency").Default = string(kbmodel.AccountCurrencyUSD)
 	createAccountPropertyList.Sort(true, true)

--- a/kbcmd/kblib/accounts.go
+++ b/kbcmd/kblib/accounts.go
@@ -12,10 +12,19 @@ import (
 
 // GetAccountByKeyOrID - get account information command
 func GetAccountByKeyOrID(ctx context.Context, c *kbclient.KillBill, keyOrID string) (*kbmodel.Account, error) {
+	return GetAccountByKeyOrIDWithMaybeBalance(ctx, c, keyOrID, false)
+}
+
+func GetAccountByKeyOrIDWithBalanceAndCBA(ctx context.Context, c *kbclient.KillBill, keyOrID string) (*kbmodel.Account, error) {
+	return GetAccountByKeyOrIDWithMaybeBalance(ctx, c, keyOrID, true)
+}
+
+func GetAccountByKeyOrIDWithMaybeBalance(ctx context.Context, c *kbclient.KillBill, keyOrID string, withBalanceAndCBA bool) (*kbmodel.Account, error) {
 	keyOrID, isID := ParseKeyOrID(keyOrID)
 	if isID {
 		resp, err := c.Account.GetAccount(ctx, &account.GetAccountParams{
 			AccountID: strfmt.UUID(keyOrID),
+			AccountWithBalanceAndCBA: &withBalanceAndCBA,
 		})
 		if err != nil {
 			return nil, err
@@ -24,6 +33,7 @@ func GetAccountByKeyOrID(ctx context.Context, c *kbclient.KillBill, keyOrID stri
 	}
 	resp, err := c.Account.GetAccountByKey(ctx, &account.GetAccountByKeyParams{
 		ExternalKey: keyOrID,
+		AccountWithBalanceAndCBA: &withBalanceAndCBA,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Bug fixes:

* Respect `KB_CREATED_BY` environment property
* Compute account balance in `acc get`
* Set a sane reference time (`time.Now()` instead of `0001-01-01T00:00:00.000Z`)

New features:

* Create external charge (`inv charge`)
* List invoice payments (`inv payments`)
* List account payments (`acc payments ls`)

Breaking changes:

* GDPR sensitive fields not required anymore when creating an account
* Deleting a payment method requires the payment method id instead of the plugin name

@fieryorc heads up regarding these changes (any concern, let me know 🐱)