### PR TITLE
Fix for TextConsumer error when processing 4xx

### DIFF
--- a/kbcmd/cmdlib/html.go
+++ b/kbcmd/cmdlib/html.go
@@ -1,0 +1,63 @@
+package cmdlib
+
+import (
+	"bytes"
+	"encoding"
+	"errors"
+	"fmt"
+	"github.com/killbill/kbcli/v2/kbcommon"
+	"io"
+	"reflect"
+
+	"github.com/go-openapi/runtime"
+)
+
+// HTMLConsumer creates a new HTML consumer
+func HTMLConsumer() runtime.Consumer {
+	return runtime.ConsumerFunc(func(reader io.Reader, data interface{}) error {
+		if reader == nil {
+			return errors.New("TextConsumer requires a reader") // early exit
+		}
+
+		buf := new(bytes.Buffer)
+		_, err := buf.ReadFrom(reader)
+		if err != nil {
+			return err
+		}
+		b := buf.Bytes()
+
+		// If the buffer is empty, no need to unmarshal it, which causes a panic.
+		if len(b) == 0 {
+			data = ""
+			return nil
+		}
+
+		if tu, ok := data.(encoding.TextUnmarshaler); ok {
+			err := tu.UnmarshalText(b)
+			if err != nil {
+				return fmt.Errorf("text consumer: %v", err)
+			}
+
+			return nil
+		}
+
+		t := reflect.TypeOf(data)
+		if data != nil && t.Kind() == reflect.Ptr {
+			v := reflect.Indirect(reflect.ValueOf(data))
+			if t.Elem().Kind() == reflect.String {
+				v.SetString(string(b))
+				return nil
+			}
+		}
+
+		// For unhandled response codes, go-swagger passes kbcommon.NewKillbillError as data
+		// See https://github.com/go-swagger/go-swagger/issues/1929
+		if kbErr, ok := data.(**kbcommon.KillbillError); ok {
+			(*kbErr).Message = string(b)
+			return nil
+		}
+
+		return fmt.Errorf("%v (%T) is not supported by the TextConsumer, %s",
+			data, data, "can be resolved by supporting TextUnmarshaler interface")
+	})
+}

--- a/kbcmd/cmdlib/registry.go
+++ b/kbcmd/cmdlib/registry.go
@@ -172,6 +172,11 @@ func (r *App) toAction(fn HandlerFn) func(c *cli.Context) error {
 		// Add text/xml producer which is not handled by openapi runtime.
 		trp.Producers["text/xml"] = runtime.TextProducer()
 		trp.Consumers["text/xml"] = runtime.TextConsumer()
+
+		// In some cases (400/401), Kill Bill might return HTML
+		// See https://github.com/killbill/kbcli/issues/11
+		trp.Consumers["text/html"] = HTMLConsumer()
+
 		trp.Debug = o.PrintDebug
 		authWriter := runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {
 			encoded := base64.StdEncoding.EncodeToString([]byte(o.Username + ":" + o.Password))


### PR DESCRIPTION
d6600191c71dfbb4936a0605fd142902ea26ea3a adds a custom `Consumer` for `text/html` responses: the `ReadResponse` function generated by `go-swagger` calls `consumer.Consume` on the `Body` directly as the default case for unhandled HTTP response codes. In case of errors, this is often `text/html`, so the default `TextConsumer` is executed, but it isn't smart enough unfortunately to return a proper `kbcommon.NewKillbillError` object (https://github.com/go-swagger/go-swagger/issues/1929).

In practice, this is what we see now:
```
# Bad credentials
~> KB_PASSWORD=bad ./kbcmd acc create
2021/09/30 10:21:26 [401]

# Bad credentials
~> KB_API_SECRET=bad ./kbcmd acc create
2021/09/30 10:21:58 [401] <!doctype html><html lang="en"><head><title>HTTP Status 401 – Unauthorized</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 401 – Unauthorized</h1><hr class="line" /><p><b>Type</b> Status Report</p><p><b>Message</b> Submitted credentials for token [org.apache.shiro.authc.UsernamePasswordToken - test, rememberMe=false] did not match the expected credentials.</p><p><b>Description</b> The request has not been applied because it lacks valid authentication credentials for the target resource.</p><hr class="line" /><h3>Apache Tomcat/8.5.71</h3></body></html>

# Bad transport
~> ./kbcmd acc create
2021/09/30 10:23:10 [400] <html>
<head><title>400 The plain HTTP request was sent to HTTPS port</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<center>The plain HTTP request was sent to HTTPS port</center>
<hr><center>nginx</center>
</body>
</html>
```

while before, we were just seeing:

```
(**kbcommon.KillbillError) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
```

7e2cd0fda4e5ef1f7868746cc8235b3dfc0bcb66 adds the `inv target-run` command to `kbcmd`:

```
~> ./kbcmd inv target-run 8aedf28a-0336-4bde-9282-3164d150cdfe TargetDate=2022-06-05
AMOUNT BALANCE INVOICE_ID                           TARGET_DATE
100    100     ca24a3a9-0530-4b06-8238-cbcee510b890 2022-06-05

  @Invoice Items:
  INVOICE_ITEM_ID                      AMOUNT RATE START_DATE PLAN
  e02b1748-80be-402e-9834-891cea54be2a 100    100  2022-05-30 c3.small-monthly
  
~> ./kbcmd inv target-run 8aedf28a-0336-4bde-9282-3164d150cdfe TargetDate=2022-06-05
No invoices to generate
```

/cc @andrenpaes for review